### PR TITLE
Track Razor Node lockfile

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "mybook-auth-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mybook-auth-server",
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds server/package-lock.json so Razor Node npm install does not leave the repository dirty.