### PR TITLE
Fix Drive sync file merging

### DIFF
--- a/src/components/common/SyncStatusBadge.tsx
+++ b/src/components/common/SyncStatusBadge.tsx
@@ -12,10 +12,10 @@ interface SyncStatusBadgeProps {
 }
 
 const statusConfig = {
-  pending: { label: 'Backup pending', className: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-300', icon: ArrowPathIcon },
-  'backing-up': { label: 'Backing up', className: 'bg-primary/10 text-primary', icon: ArrowPathIcon },
-  'backed-up': { label: 'Backed up', className: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300', icon: CheckCircleIcon },
-  failed: { label: 'Backup failed', className: 'bg-destructive/10 text-destructive', icon: ExclamationCircleIcon },
+  pending: { label: 'Syncing', className: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-300', icon: ArrowPathIcon },
+  'backing-up': { label: 'Syncing', className: 'bg-primary/10 text-primary', icon: ArrowPathIcon },
+  'backed-up': { label: 'Synced', className: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300', icon: CheckCircleIcon },
+  failed: { label: 'Sync paused', className: 'bg-destructive/10 text-destructive', icon: ExclamationCircleIcon },
   offline: { label: 'Offline', className: 'bg-muted text-muted-foreground', icon: ExclamationCircleIcon },
 } as const
 

--- a/src/components/document-editor/EditorStatus.tsx
+++ b/src/components/document-editor/EditorStatus.tsx
@@ -4,12 +4,12 @@ import type { EditorSaveStatus } from '../../types/files'
 
 const config = {
   editing: ['Editing', PencilIcon],
-  'saving-locally': ['Saving locally', ArrowPathIcon],
-  'saved-locally': ['Saved locally', CheckCircleIcon],
-  pending: ['Backup pending', CloudArrowUpIcon],
-  'backing-up': ['Backing up', ArrowPathIcon],
-  'backed-up': ['Backed up', CheckCircleIcon],
-  failed: ['Backup failed', ExclamationCircleIcon],
+  'saving-locally': ['Saving', ArrowPathIcon],
+  'saved-locally': ['Saved', CheckCircleIcon],
+  pending: ['Syncing', CloudArrowUpIcon],
+  'backing-up': ['Syncing', ArrowPathIcon],
+  'backed-up': ['Synced', CheckCircleIcon],
+  failed: ['Sync paused', ExclamationCircleIcon],
   offline: ['Offline', SignalSlashIcon],
 } as const
 

--- a/src/components/document-editor/TiptapDocumentEditor.tsx
+++ b/src/components/document-editor/TiptapDocumentEditor.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { fileRepository } from '../../database/repositories'
 import { useAutosave } from '../../hooks/useAutosave'
-import { backupDocumentToDrive, copyDriveFileLink, getDriveFileStatus, openDriveFileInBrowser } from '../../services/googleDrive'
+import { backupDocumentToDrive, copyDriveFileLink, openDriveFileInBrowser } from '../../services/googleDrive'
 import { documentToMyBookMarkdown, downloadMyBookMarkdown, myBookMarkdownToDocument } from '../../utils/mybookMarkdown'
 import { AppButton } from '../common/AppButton'
 import { EmptyState } from '../common/EmptyState'
@@ -106,9 +106,6 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
   const [docxBlob, setDocxBlob] = useState<Blob | null>(null)
   const [docxMessage, setDocxMessage] = useState('')
   const [cloudMessage, setCloudMessage] = useState<string | null>(null)
-  const [driveExists, setDriveExists] = useState<boolean | null>(null)
-  const [isCheckingDrive, setIsCheckingDrive] = useState(false)
-  const [hasCheckedDrive, setHasCheckedDrive] = useState(false)
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null)
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
   const [isFullWidth, setIsFullWidth] = useState(false)
@@ -226,23 +223,6 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
 
   useEffect(() => { if (file) setTitle(file.name) }, [file])
   useEffect(() => {
-    if (!file?.driveFileId) { setDriveExists(null); return }
-    void getDriveFileStatus(file.driveFileId).then((result) => setDriveExists(result.exists))
-  }, [file?.driveFileId])
-  const checkDriveChanges = useCallback(async () => {
-    if (!file?.driveFileId || !file.lastSyncedAt) { setHasCheckedDrive(true); return }
-    setIsCheckingDrive(true)
-    try {
-      const result = await getDriveFileStatus(file.driveFileId)
-      setDriveExists(result.exists)
-      if (result.exists) setCloudMessage('Drive backup is available.')
-      else if (result.error) setCloudMessage(result.error)
-    } finally { setIsCheckingDrive(false); setHasCheckedDrive(true) }
-  }, [file?.driveFileId, file?.lastSyncedAt])
-  useEffect(() => {
-    void checkDriveChanges()
-  }, [checkDriveChanges])
-  useEffect(() => {
     if (!editor || !file || !isHydrated) return
     if (loadedId === file.id && content === editorContentRef.current) return
     editor.commands.setContent(parseContent(content), { emitUpdate: false })
@@ -253,22 +233,22 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     if (title !== file?.name && file) await fileRepository.update(file.id, { name: title })
   }, [file, title])
   useEffect(() => {
-    if (!file || file.isDeleted || isCheckingDrive || !hasCheckedDrive) return
+    if (!file || file.isDeleted) return
     if (cloudTimerRef.current !== null) window.clearTimeout(cloudTimerRef.current)
     if (status !== 'pending' && status !== 'saved-locally') return
     cloudTimerRef.current = window.setTimeout(() => {
       if (cloudFlightRef.current || !file || file.isDeleted || file.type !== 'document') return
       cloudFlightRef.current = true
-      setCloudMessage('Preparing cloud backup…')
+      setCloudMessage('Syncing…')
       void (async () => {
         try {
           const [savedContent] = await Promise.all([save(), saveTitle()])
           if (!savedContent) {
-            setCloudMessage('Local save failed. Cloud backup paused.')
+            setCloudMessage('Save failed. Sync paused.')
             return
           }
           const result = await backupDocumentToDrive({ fileId: file.id, title, content, folderId: file.folderId })
-          if (result.success) setCloudMessage(result.created ? 'Google Drive backup created.' : 'Google Drive backup updated.')
+          if (result.success) setCloudMessage('Synced')
           else setCloudMessage(result.error)
         } finally {
           cloudFlightRef.current = false
@@ -279,7 +259,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
       if (cloudTimerRef.current !== null) window.clearTimeout(cloudTimerRef.current)
       cloudTimerRef.current = null
     }
-  }, [content, file, hasCheckedDrive, isCheckingDrive, save, saveTitle, status, title])
+  }, [content, file, save, saveTitle, status, title])
 
   if (file === undefined || !editor) return <div role="status" className="p-4 text-muted-foreground">Loading editor…</div>
   if (!file || file.isDeleted) return <EmptyState title="Document not found" description="This document may have been moved to Trash or deleted." />
@@ -290,15 +270,14 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     await saveAll()
     const latest = (await fileRepository.get(file.id)).data
     if (!latest) return
-    setCloudMessage('Backing up to Google Drive…')
+    setCloudMessage('Syncing…')
     const result = await backupDocumentToDrive({ fileId: latest.id, title: latest.name, content: latest.content, folderId: latest.folderId })
-    setCloudMessage(result.success ? 'Google Drive backup complete.' : result.error ?? 'Google Drive backup failed.')
-    if (result.success) setDriveExists(true)
+    setCloudMessage(result.success ? 'Synced' : result.error ?? 'Sync failed.')
   }
   const copyDriveLink = async () => {
     if (!file.driveFileId) return
     const result = await copyDriveFileLink(file.driveFileId)
-    setCloudMessage(result.success ? 'Drive link copied.' : result.error ?? 'Could not copy the Drive link.')
+    setCloudMessage(result.success ? 'Backup link copied.' : result.error ?? 'Could not copy the backup link.')
   }
   const close = async () => { await saveAll(); navigate(file.folderId ? `/folders/${file.folderId}` : '/home') }
 
@@ -410,7 +389,6 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     else if (action === 'download-docx') void exportDocx(true)
     else if (action === 'prepare-docx') void exportDocx(false)
     else if (action === 'open-drive' && file.driveFileId) void openDriveFileInBrowser(file.driveFileId)
-    else if (action === 'refresh') void checkDriveChanges()
     else if (action === 'import') importInputRef.current?.click()
     else if (action === 'undo') editor.chain().focus().undo().run()
     else if (action === 'redo') editor.chain().focus().redo().run()
@@ -465,19 +443,18 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
             <input id="document-title" value={title} onChange={(event) => setTitle(event.target.value)} onBlur={() => void saveTitle()} className="h-8 w-full truncate rounded-[6px] bg-transparent text-base font-semibold outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background" />
             <EditorStatus status={status} />
             {cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}
-            {file.driveFileId ? <p className="mt-1 text-xs text-muted-foreground">{driveExists === false ? 'Drive file not found' : 'Drive file exists'}{file.lastSyncedAt ? ` · Last backup ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? ` · ${file.syncError}` : ''}</p> : null}
+            {file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}
           </div>
-          <Dropdown><Dropdown.Trigger aria-label="More document actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Document actions" onAction={handleDocumentAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Back up now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId || driveExists === false}>Open in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId || driveExists === false}>Copy Drive link</Dropdown.Item><Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item><Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item><Dropdown.Item id="prepare-docx">Prepare DOCX</Dropdown.Item><Dropdown.Item id="import">Import document</Dropdown.Item><Dropdown.Item id="close">Close document</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
+          <Dropdown><Dropdown.Trigger aria-label="More document actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Document actions" onAction={handleDocumentAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item><Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item><Dropdown.Item id="prepare-docx">Prepare DOCX</Dropdown.Item><Dropdown.Item id="import">Import document</Dropdown.Item><Dropdown.Item id="close">Close document</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
           <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void saveAll()}>Save</AppButton>
-          <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Back up now</AppButton>
-          <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId || driveExists === false} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open in Drive</AppButton>
-          <AppButton className="hidden sm:flex" variant="secondary" isDisabled={isCheckingDrive || !file.driveFileId} onPress={() => void checkDriveChanges()}>Refresh</AppButton>
+          <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Sync now</AppButton>
+          <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open backup</AppButton>
         </div>
         <nav aria-label="Desktop document commands" className="hidden min-h-10 items-center gap-1 border-t border-[var(--app-border)] md:flex">
           <DesktopMenu label="Document">
             <Dropdown.Menu aria-label="Document menu" onAction={handleDocumentAction}>
               <Dropdown.Item id="save">Save now</Dropdown.Item>
-              <Dropdown.Item id="backup">Back up now</Dropdown.Item>
+              <Dropdown.Item id="backup">Sync now</Dropdown.Item>
               <Dropdown.Item id="import">Import document</Dropdown.Item>
               <Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item>
               <Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item>
@@ -500,9 +477,8 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
               <Dropdown.Item id="zoom-100">Zoom 100%</Dropdown.Item>
               <Dropdown.Item id="zoom-125">Zoom 125%</Dropdown.Item>
               <Dropdown.Item id="zoom-150">Zoom 150%</Dropdown.Item>
-              <Dropdown.Item id="open-drive" isDisabled={!file.driveFileId || driveExists === false}>Open in Drive</Dropdown.Item>
-              <Dropdown.Item id="copy-link" isDisabled={!file.driveFileId || driveExists === false}>Copy Drive link</Dropdown.Item>
-              <Dropdown.Item id="refresh" isDisabled={isCheckingDrive || !file.driveFileId}>Refresh backup status</Dropdown.Item>
+              <Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item>
+              <Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item>
             </Dropdown.Menu>
           </DesktopMenu>
           <DesktopMenu label="Insert">

--- a/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
+++ b/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
@@ -5,12 +5,12 @@ import UniverPresetSheetsCoreEnUS from '@univerjs/preset-sheets-core/locales/en-
 import { UniverSheetsCorePreset } from '@univerjs/preset-sheets-core'
 import { createUniver, LocaleType, mergeLocales } from '@univerjs/presets'
 import { useLiveQuery } from 'dexie-react-hooks'
-import { useCallback, useEffect, useRef, useState, type Key } from 'react'
+import { useEffect, useRef, useState, type Key } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { fileRepository } from '../../database/repositories'
 import { useAutosave } from '../../hooks/useAutosave'
-import { backupSpreadsheetToDrive, copyDriveFileLink, getDriveFileStatus, openDriveFileInBrowser } from '../../services/googleDrive'
+import { backupSpreadsheetToDrive, copyDriveFileLink, openDriveFileInBrowser } from '../../services/googleDrive'
 import type { UniverWorkbookSnapshot, XlsxResult } from '../../utils/xlsx'
 import { AppButton } from '../common/AppButton'
 import { EmptyState } from '../common/EmptyState'
@@ -38,9 +38,6 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   const [xlsxWarnings, setXlsxWarnings] = useState<string[]>([])
   const [isConverting, setIsConverting] = useState(false)
   const [cloudMessage, setCloudMessage] = useState<string | null>(null)
-  const [driveExists, setDriveExists] = useState<boolean | null>(null)
-  const [isCheckingDrive, setIsCheckingDrive] = useState(false)
-  const [hasCheckedDrive, setHasCheckedDrive] = useState(false)
   const cloudTimerRef = useRef<number | null>(null)
   const cloudFlightRef = useRef(false)
   const latestSnapshot = useRef('')
@@ -49,24 +46,6 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   contentRef.current = content
   setContentRef.current = setContent
   const fileName = file?.name
-
-  useEffect(() => {
-    if (!file?.driveFileId) { setDriveExists(null); return }
-    void getDriveFileStatus(file.driveFileId).then((result) => setDriveExists(result.exists))
-  }, [file?.driveFileId])
-  const checkDriveChanges = useCallback(async () => {
-    if (!file?.driveFileId || !file.lastSyncedAt) { setHasCheckedDrive(true); return }
-    setIsCheckingDrive(true)
-    try {
-      const result = await getDriveFileStatus(file.driveFileId)
-      setDriveExists(result.exists)
-      if (result.exists) setCloudMessage('Drive backup is available.')
-      else if (result.error) setCloudMessage(result.error)
-    } finally { setIsCheckingDrive(false); setHasCheckedDrive(true) }
-  }, [file?.driveFileId, file?.lastSyncedAt])
-  useEffect(() => {
-    void checkDriveChanges()
-  }, [checkDriveChanges])
 
   useEffect(() => {
     const viewport = window.visualViewport
@@ -117,22 +96,22 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   }, [fileId, fileName, isHydrated, workbookRevision])
 
   useEffect(() => {
-    if (!file || file.isDeleted || file.type !== 'spreadsheet' || !isHydrated || isCheckingDrive || !hasCheckedDrive) return
+    if (!file || file.isDeleted || file.type !== 'spreadsheet' || !isHydrated) return
     if (cloudTimerRef.current !== null) window.clearTimeout(cloudTimerRef.current)
     if (status !== 'pending' && status !== 'saved-locally') return
     cloudTimerRef.current = window.setTimeout(() => {
       if (cloudFlightRef.current || !file || file.isDeleted) return
       cloudFlightRef.current = true
-      setCloudMessage('Preparing cloud backup…')
+      setCloudMessage('Syncing…')
       void (async () => {
         try {
           const saved = await save()
-          if (!saved) { setCloudMessage('Local save failed. Cloud backup paused.'); return }
+          if (!saved) { setCloudMessage('Save failed. Sync paused.'); return }
           const latest = await fileRepository.get(file.id)
           const latestFile = latest.data
           if (!latestFile) { setCloudMessage('Spreadsheet could not be found.'); return }
           const result = await backupSpreadsheetToDrive({ fileId: file.id, title: latestFile.name, content: latestFile.content, folderId: latestFile.folderId })
-          setCloudMessage(result.success ? (result.created ? 'Google Drive backup created.' : 'Google Drive backup updated.') : result.error)
+          setCloudMessage(result.success ? 'Synced' : result.error)
         } finally {
           cloudFlightRef.current = false
         }
@@ -142,7 +121,7 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
       if (cloudTimerRef.current !== null) window.clearTimeout(cloudTimerRef.current)
       cloudTimerRef.current = null
     }
-  }, [content, file, hasCheckedDrive, isCheckingDrive, isHydrated, save, status])
+  }, [content, file, isHydrated, save, status])
 
   if (file === undefined) return <div role="status" className="p-4 text-muted-foreground">Loading spreadsheet…</div>
   if (!file || file.isDeleted) return <EmptyState title="Spreadsheet not found" description="This spreadsheet may have been moved to Trash or deleted." />
@@ -200,16 +179,15 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     await save()
     const latest = (await fileRepository.get(file.id)).data
     if (!latest) return
-    setCloudMessage('Backing up to Google Drive…')
+    setCloudMessage('Syncing…')
     const result = await backupSpreadsheetToDrive({ fileId: latest.id, title: latest.name, content: latest.content, folderId: latest.folderId })
-    setCloudMessage(result.success ? 'Google Drive backup complete.' : result.error ?? 'Google Drive backup failed.')
-    if (result.success) setDriveExists(true)
+    setCloudMessage(result.success ? 'Synced' : result.error ?? 'Sync failed.')
   }
 
   const copyDriveLink = async () => {
     if (!file.driveFileId) return
     const result = await copyDriveFileLink(file.driveFileId)
-    setCloudMessage(result.success ? 'Drive link copied.' : result.error ?? 'Could not copy the Drive link.')
+    setCloudMessage(result.success ? 'Backup link copied.' : result.error ?? 'Could not copy the backup link.')
   }
   const handleMenuAction = (key: Key) => {
     if (key === 'save') void save()
@@ -227,12 +205,11 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     <section className="-mx-4 -my-6 flex min-h-0 flex-col sm:-mx-6 lg:-mx-8" style={{ height: editorHeight }}>
       <header className="z-30 flex min-h-16 shrink-0 items-center gap-2 border-b border-[var(--app-border)] bg-background px-2 sm:px-4">
         <button type="button" onClick={() => void close()} aria-label="Close spreadsheet" className="flex size-11 shrink-0 items-center justify-center rounded-[10px]"><ArrowLeftIcon aria-hidden="true" className="size-5" /></button>
-        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={status} />{cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}{file.driveFileId ? <p className="mt-1 text-xs text-muted-foreground">{driveExists === false ? 'Drive file not found' : 'Drive file exists'}{file.lastSyncedAt ? ` · Last backup ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? ` · ${file.syncError}` : ''}</p> : null}</div>
-        <Dropdown><Dropdown.Trigger aria-label="More spreadsheet actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Spreadsheet actions" onAction={handleMenuAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Back up now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId || driveExists === false}>Open in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId || driveExists === false}>Copy Drive link</Dropdown.Item><Dropdown.Item id="download-local">Download local copy</Dropdown.Item><Dropdown.Item id="import"><span className="flex items-center gap-2"><ArrowUpTrayIcon aria-hidden="true" className="size-5" />Import XLSX</span></Dropdown.Item><Dropdown.Item id="export">Export XLSX</Dropdown.Item><Dropdown.Item id="download"><span className="flex items-center gap-2"><ArrowDownTrayIcon aria-hidden="true" className="size-5" />Download XLSX</span></Dropdown.Item><Dropdown.Item id="close">Close spreadsheet</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
+        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={status} />{cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}{file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}</div>
+        <Dropdown><Dropdown.Trigger aria-label="More spreadsheet actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Spreadsheet actions" onAction={handleMenuAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="download-local">Download local copy</Dropdown.Item><Dropdown.Item id="import"><span className="flex items-center gap-2"><ArrowUpTrayIcon aria-hidden="true" className="size-5" />Import XLSX</span></Dropdown.Item><Dropdown.Item id="export">Export XLSX</Dropdown.Item><Dropdown.Item id="download"><span className="flex items-center gap-2"><ArrowDownTrayIcon aria-hidden="true" className="size-5" />Download XLSX</span></Dropdown.Item><Dropdown.Item id="close">Close spreadsheet</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
         <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void save()}>Save</AppButton>
-        <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Back up now</AppButton>
-        <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId || driveExists === false} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open in Drive</AppButton>
-        <AppButton className="hidden sm:flex" variant="secondary" isDisabled={isCheckingDrive || !file.driveFileId} onPress={() => void checkDriveChanges()}>Refresh</AppButton>
+        <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Sync now</AppButton>
+        <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open backup</AppButton>
       </header>
       <input ref={importInputRef} type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" className="sr-only" aria-label="Import XLSX file" onChange={(event) => void importXlsx(event.target.files?.[0])} />
       {(isConverting || xlsxMessage || xlsxWarnings.length > 0) && (

--- a/src/database/repositories.test.ts
+++ b/src/database/repositories.test.ts
@@ -65,4 +65,83 @@ describe('IndexedDB repositories', () => {
     expect(first.data?.name).toBe('Notes copy')
     expect(second.data?.name).toBe('Notes copy 2')
   })
+
+  it('lists one logical file when local duplicate records exist', async () => {
+    const now = new Date().toISOString()
+    await db.files.bulkAdd([
+      {
+        id: 'local-copy',
+        driveFileId: null,
+        name: 'Project Plan',
+        type: 'document',
+        folderId: null,
+        content: 'local',
+        mimeType: 'application/x-mybook-document',
+        createdAt: now,
+        updatedAt: '2026-08-22T08:00:00.000Z',
+        lastSyncedAt: null,
+        syncStatus: 'pending',
+        isDeleted: false,
+      },
+      {
+        id: 'synced-copy',
+        driveFileId: 'drive-project-plan',
+        name: 'Project Plan',
+        type: 'document',
+        folderId: null,
+        content: 'synced',
+        mimeType: 'application/x-mybook-document',
+        createdAt: now,
+        updatedAt: '2026-08-22T07:00:00.000Z',
+        lastSyncedAt: '2026-08-22T07:00:00.000Z',
+        syncStatus: 'backed-up',
+        isDeleted: false,
+      },
+    ])
+
+    const files = await fileRepository.list()
+
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({ id: 'synced-copy', driveFileId: 'drive-project-plan' })
+  })
+
+  it('hides backup file extensions from app-visible names', async () => {
+    const now = new Date().toISOString()
+    await db.files.bulkAdd([
+      {
+        id: 'markdown-backup-name',
+        driveFileId: 'drive-markdown',
+        name: 'Meeting Notes.mybook.md',
+        type: 'document',
+        folderId: null,
+        content: '',
+        mimeType: 'application/x-mybook-document',
+        createdAt: now,
+        updatedAt: now,
+        lastSyncedAt: now,
+        syncStatus: 'backed-up',
+        isDeleted: false,
+      },
+      {
+        id: 'spreadsheet-backup-name',
+        driveFileId: 'drive-sheet',
+        name: 'Budget.xlsx',
+        type: 'spreadsheet',
+        folderId: null,
+        content: '',
+        mimeType: 'application/x-mybook-spreadsheet',
+        createdAt: now,
+        updatedAt: now,
+        lastSyncedAt: now,
+        syncStatus: 'backed-up',
+        isDeleted: false,
+      },
+    ])
+
+    const files = await fileRepository.list()
+    const document = (await fileRepository.get('markdown-backup-name')).data
+
+    expect(files.map((file) => file.name).sort()).toEqual(['Budget', 'Meeting Notes'])
+    expect(document?.name).toBe('Meeting Notes')
+  })
 })

--- a/src/database/repositories.ts
+++ b/src/database/repositories.ts
@@ -18,6 +18,14 @@ function cleanName(name: string) {
   return name.trim().replace(/\s+/g, ' ')
 }
 
+function appFileName(name: string, type: FileType) {
+  const cleaned = cleanName(name)
+  const withoutExtension = type === 'spreadsheet'
+    ? cleaned.replace(/\.xlsx$/i, '')
+    : cleaned.replace(/\.mybook\.md$/i, '').replace(/\.md$/i, '').replace(/\.docx$/i, '')
+  return cleanName(withoutExtension) || cleaned
+}
+
 async function queueFolderSync(folderId: string, operation: SyncOperation, errorMessage: string | null = null) {
   const existing = await db.syncQueue.filter((item) => item.entityType === 'folder' && item.entityId === folderId && item.status !== 'completed').first()
   const now = new Date().toISOString()
@@ -131,7 +139,33 @@ export const processPendingDriveFolderSync = processPendingDriveSync
 
 async function uniqueFileName(name: string, folderId: string | null, excludedId?: string) {
   const files = await db.files.filter((file) => file.folderId === folderId).toArray()
-  return !files.some((file) => file.id !== excludedId && !file.isDeleted && file.folderId === folderId && file.name.toLocaleLowerCase() === name.toLocaleLowerCase())
+  return !files.some((file) => file.id !== excludedId && !file.isDeleted && file.folderId === folderId && appFileName(file.name, file.type).toLocaleLowerCase() === name.toLocaleLowerCase())
+}
+
+function logicalFileKeys(file: MyBookFile) {
+  const nameKey = `${file.folderId ?? 'root'}:${file.type}:${appFileName(file.name, file.type).toLocaleLowerCase()}`
+  return file.driveFileId ? [`drive:${file.driveFileId}`, `name:${nameKey}`] : [`name:${nameKey}`]
+}
+
+function filePreference(file: MyBookFile) {
+  const syncScore = file.driveFileId ? 100 : 0
+  const backedUpScore = file.syncStatus === 'backed-up' ? 20 : 0
+  const syncedAt = file.lastSyncedAt ? new Date(file.lastSyncedAt).getTime() : 0
+  const updatedAt = new Date(file.updatedAt).getTime()
+  return syncScore + backedUpScore + Math.max(syncedAt, updatedAt) / 1_000_000_000_000
+}
+
+function uniqueLogicalFiles(files: MyBookFile[]) {
+  const sorted = [...files].sort((a, b) => filePreference(b) - filePreference(a))
+  const seen = new Set<string>()
+  const visible: MyBookFile[] = []
+  for (const file of sorted) {
+    const keys = logicalFileKeys(file)
+    if (keys.some((key) => seen.has(key))) continue
+    keys.forEach((key) => seen.add(key))
+    visible.push(file)
+  }
+  return visible
 }
 
 export const fileRepository = {
@@ -146,14 +180,19 @@ export const fileRepository = {
       return { success: true, data: synced ?? file }
     } catch (error) { return failure(error, 'Could not create file.') }
   },
-  async get(id: string) { try { return { success: true, data: await db.files.get(id) } } catch (error) { return failure(error, 'Could not load file.') } },
+  async get(id: string) {
+    try {
+      const file = await db.files.get(id)
+      return { success: true, data: file ? { ...file, name: appFileName(file.name, file.type) } : file }
+    } catch (error) { return failure(error, 'Could not load file.') }
+  },
   async update(id: string, changes: Partial<Omit<MyBookFile, 'id'>>): Promise<RepositoryResult> {
     try {
       const existing = await db.files.get(id)
       if (!existing) return { success: false, error: 'File could not be found.' }
       if (changes.content !== undefined && changes.content === existing.content && Object.keys(changes).every((key) => key === 'content')) return { success: true }
       if (changes.name !== undefined) {
-        const name = cleanName(changes.name)
+        const name = appFileName(changes.name, existing.type)
         if (!name) return { success: false, error: 'File name cannot be empty.' }
         const file = await db.files.get(id)
         if (!file) return { success: false, error: 'File could not be found.' }
@@ -189,8 +228,21 @@ export const fileRepository = {
     } catch (error) { return failure(error, 'Could not restore file.') }
   },
   async permanentlyDelete(id: string): Promise<RepositoryResult> { try { await db.files.delete(id); return { success: true } } catch (error) { return failure(error, 'Could not permanently delete file.') } },
-  async list(includeDeleted = false): Promise<MyBookFile[]> { try { return await db.files.filter((file) => includeDeleted || !file.isDeleted).toArray() } catch (error) { devLog('error', 'Could not list files.', error); return [] } },
-  async search(query: string): Promise<MyBookFile[]> { try { const value = query.trim().toLocaleLowerCase(); return await db.files.filter((file) => !file.isDeleted && file.name.toLocaleLowerCase().includes(value)).toArray() } catch (error) { devLog('error', 'Could not search files.', error); return [] } },
+  async list(includeDeleted = false): Promise<MyBookFile[]> {
+    try {
+      const files = await db.files.filter((file) => includeDeleted || !file.isDeleted).toArray()
+      const normalized = files.map((file) => ({ ...file, name: appFileName(file.name, file.type) }))
+      return includeDeleted ? normalized : uniqueLogicalFiles(normalized)
+    } catch (error) { devLog('error', 'Could not list files.', error); return [] }
+  },
+  async search(query: string): Promise<MyBookFile[]> {
+    try {
+      const value = query.trim().toLocaleLowerCase()
+      const files = (await db.files.filter((file) => !file.isDeleted && appFileName(file.name, file.type).toLocaleLowerCase().includes(value)).toArray())
+        .map((file) => ({ ...file, name: appFileName(file.name, file.type) }))
+      return uniqueLogicalFiles(files)
+    } catch (error) { devLog('error', 'Could not search files.', error); return [] }
+  },
   async duplicate(id: string): Promise<RepositoryResult<MyBookFile>> {
     try {
       const source = await db.files.get(id)

--- a/src/hooks/useDriveBootstrap.ts
+++ b/src/hooks/useDriveBootstrap.ts
@@ -1,10 +1,21 @@
 import { useEffect, useState } from 'react'
 
-import { backfillLocalFoldersToDrive, ensureMyBookDriveFolder, getDriveFolderStatus } from '../services/googleDrive'
+import { backfillLocalFoldersToDrive, ensureMyBookDriveFolder, getDriveFolderStatus, importDriveFilesToLocal, importDriveFoldersToLocal } from '../services/googleDrive'
 import { useAuthStore } from '../stores/useAuthStore'
 import { folderRepository, processPendingDriveFolderSync, settingsRepository } from '../database/repositories'
 
 const DRIVE_BACKFILL_KEY = 'google-drive.folder-backfill-complete'
+let importDriveBackupsFlight: Promise<void> | null = null
+
+async function importDriveBackupsToLocal() {
+  importDriveBackupsFlight ??= (async () => {
+    await importDriveFoldersToLocal()
+    await importDriveFilesToLocal()
+  })().finally(() => {
+    importDriveBackupsFlight = null
+  })
+  return importDriveBackupsFlight
+}
 
 export function useDriveBootstrap() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
@@ -30,6 +41,12 @@ export function useDriveBootstrap() {
             : result.error)
         }
         await processPendingDriveFolderSync()
+        try {
+          await importDriveBackupsToLocal()
+          if (!cancelled) setStatusMessage('Synced across devices.')
+        } catch (error) {
+          if (!cancelled) setStatusMessage(error instanceof Error ? error.message : 'Sync paused.')
+        }
         const backfillFlag = (await settingsRepository.get(DRIVE_BACKFILL_KEY)).data?.value
         if (backfillFlag !== true) {
           const folders = await folderRepository.list()
@@ -46,7 +63,9 @@ export function useDriveBootstrap() {
       }
     }
     void run()
-    const onlineHandler = () => { void processPendingDriveFolderSync() }
+    const onlineHandler = () => {
+      void processPendingDriveFolderSync().then(() => importDriveBackupsToLocal()).catch(() => undefined)
+    }
     window.addEventListener('online', onlineHandler)
     return () => {
       cancelled = true

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -76,7 +76,7 @@ export function SettingsPage() {
               : 'MyBook folder is not connected yet.'}
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          {statusMessage ?? 'MyBook stores the folder ID locally and backfills existing folders into Drive after login.'}
+          {statusMessage ?? 'MyBook syncs your files across signed-in devices using Drive backups.'}
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
           <AppButton
@@ -93,9 +93,9 @@ export function SettingsPage() {
           </AppButton>
         </div>
         <dl className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {([['Local files', backupStats.total], ['Backed up', backupStats.backedUp], ['Pending', backupStats.pending], ['Failed', backupStats.failed]] as const).map(([label, value]) => <div key={label} className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">{label}</dt><dd className="mt-1 text-2xl font-semibold">{value}</dd></div>)}
+          {([['Local files', backupStats.total], ['Synced', backupStats.backedUp], ['Syncing', backupStats.pending], ['Sync paused', backupStats.failed]] as const).map(([label, value]) => <div key={label} className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">{label}</dt><dd className="mt-1 text-2xl font-semibold">{value}</dd></div>)}
         </dl>
-        {backupStats.failed > 0 ? <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Backup failures</p>{files.filter((file) => file.syncStatus === 'failed').map((file) => <p key={file.id} className="mt-1 text-muted-foreground">{file.name}: {file.syncError ?? 'Backup failed.'}</p>)}</div> : null}
+        {backupStats.failed > 0 ? <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Sync paused</p>{files.filter((file) => file.syncStatus === 'failed').map((file) => <p key={file.id} className="mt-1 text-muted-foreground">{file.name}: {file.syncError ?? 'Sync failed.'}</p>)}</div> : null}
       </section>
       <section aria-labelledby="files-heading" className="rounded-2xl bg-muted/70 p-4">
         <h2 id="files-heading" className="text-base font-semibold leading-6">Files</h2>

--- a/src/services/googleDrive.test.ts
+++ b/src/services/googleDrive.test.ts
@@ -19,9 +19,15 @@ vi.mock('../database/db', () => ({
       toArray: vi.fn(),
       add: vi.fn(),
       update: vi.fn(),
+      get: vi.fn(),
+    },
+    fileVersions: {
+      add: vi.fn(),
     },
     folders: {
       toArray: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
     },
     settings: {
       get: vi.fn(),
@@ -43,7 +49,9 @@ const mockedGetState = vi.mocked(useAuthStore.getState)
 
 describe('googleDrive helpers', () => {
   beforeEach(() => {
-    mockedGetState.mockReturnValue({ getAccessToken: () => 'token' } as never)
+    vi.clearAllMocks()
+    mockedGetState.mockReturnValue({ getAccessToken: () => Promise.resolve('token') } as never)
+    mockedFiles.get.mockResolvedValue(undefined)
     vi.stubGlobal('navigator', { onLine: true })
   })
 
@@ -108,6 +116,40 @@ describe('googleDrive helpers', () => {
     expect(mockedFiles.add).toHaveBeenCalledWith(expect.objectContaining({
       driveFileId: 'doc-1',
       name: 'Drive Note',
+      isDeleted: false,
+    }))
+  })
+
+  it('merges an imported Drive file into an existing local file with the same name', async () => {
+    mockedSettings.get.mockResolvedValue({ key: 'google-drive.mybook-folder-id', value: null, updatedAt: '2026-07-24T00:00:00.000Z' })
+    mockedFolders.toArray.mockResolvedValue([])
+    mockedFiles.toArray.mockResolvedValue([{
+      id: 'local-note',
+      driveFileId: null,
+      name: 'Drive Note',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    }])
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [{ id: 'root-folder', name: 'MyBook', mimeType: 'application/vnd.google-apps.folder' }] }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [{ id: 'doc-1', name: 'Drive Note.mybook.md', mimeType: 'text/markdown', modifiedTime: '2026-08-22T10:00:00.000Z' }] }) })
+      .mockResolvedValueOnce({ ok: true, text: vi.fn().mockResolvedValue('---\ntitle: Drive Note\n---\n\nHello') })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [] }) }))
+
+    await importDriveFilesToLocal()
+
+    expect(mockedFiles.add).not.toHaveBeenCalled()
+    expect(mockedFiles.update).toHaveBeenCalledWith('local-note', expect.objectContaining({
+      driveFileId: 'doc-1',
+      name: 'Drive Note',
+      syncStatus: 'backed-up',
       isDeleted: false,
     }))
   })

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -104,7 +104,7 @@ async function getDriveFileContent(fileId: string) {
 }
 
 async function getDriveFileBlob(fileId: string) {
-  const accessToken = useAuthStore.getState().getAccessToken()
+  const accessToken = await useAuthStore.getState().getAccessToken()
   if (!accessToken) throw new Error('Your Google session expired. Please sign in again.')
   const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`, {
     headers: { Authorization: `Bearer ${accessToken}` },
@@ -114,7 +114,7 @@ async function getDriveFileBlob(fileId: string) {
 }
 
 async function exportGoogleWorkspaceFile(fileId: string, mimeType: string) {
-  const accessToken = useAuthStore.getState().getAccessToken()
+  const accessToken = await useAuthStore.getState().getAccessToken()
   if (!accessToken) throw new Error('Your Google session expired. Please sign in again.')
   const response = await fetch(`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}/export?mimeType=${encodeURIComponent(mimeType)}`, {
     headers: { Authorization: `Bearer ${accessToken}` },
@@ -430,7 +430,7 @@ function safeXlsxName(name: string) {
 }
 
 async function uploadXlsxBlob(name: string, blob: Blob, parentId: string, fileId?: string | null, targetMimeType = XLSX_MIME) {
-  const accessToken = useAuthStore.getState().getAccessToken()
+  const accessToken = await useAuthStore.getState().getAccessToken()
   if (!accessToken) throw new Error('Your Google session expired. Please sign in again.')
   const metadata = {
     name: targetMimeType === GOOGLE_SHEET_MIME ? name.replace(/\.xlsx$/i, '').trim() || 'Untitled spreadsheet' : safeXlsxName(name),
@@ -509,7 +509,7 @@ export async function copyDriveFileLink(fileId: string): Promise<{ success: bool
     await navigator.clipboard.writeText(`https://drive.google.com/file/d/${encodeURIComponent(fileId)}/view`)
     return { success: true }
   } catch {
-    return { success: false, error: 'Could not copy the Google Drive link.' }
+    return { success: false, error: 'Could not copy the backup link.' }
   }
 }
 
@@ -633,6 +633,16 @@ function localFileName(name: string, type: 'document' | 'spreadsheet') {
   return type === 'spreadsheet'
     ? name.replace(/\.xlsx$/i, '')
     : name.replace(/\.mybook\.md$/i, '').replace(/\.md$/i, '').replace(/\.docx$/i, '')
+}
+
+function preferLocalFileMatch<T extends { driveFileId: string | null; syncStatus: string; lastSyncedAt: string | null; updatedAt: string }>(current: T | undefined, candidate: T) {
+  if (!current) return candidate
+  const currentScore = (current.driveFileId ? 100 : 0) + (current.syncStatus === 'backed-up' ? 20 : 0)
+  const candidateScore = (candidate.driveFileId ? 100 : 0) + (candidate.syncStatus === 'backed-up' ? 20 : 0)
+  if (candidateScore !== currentScore) return candidateScore > currentScore ? candidate : current
+  const currentTime = new Date(current.lastSyncedAt ?? current.updatedAt).getTime()
+  const candidateTime = new Date(candidate.lastSyncedAt ?? candidate.updatedAt).getTime()
+  return candidateTime > currentTime ? candidate : current
 }
 
 function normalizedTitle(value: string) {
@@ -789,8 +799,10 @@ export async function importDriveFilesToLocal() {
   const byDriveId = new Map(localFiles.filter((file) => file.driveFileId).map((file) => [file.driveFileId as string, file]))
   const byNameAndParent = new Map<string, typeof localFiles[number]>()
   for (const file of localFiles) {
-    byNameAndParent.set(`${file.folderId ?? 'root'}:${file.name.toLowerCase()}`, file)
-    byNameAndParent.set(`${file.folderId ?? 'root'}:${localFileName(file.name, file.type).toLowerCase()}`, file)
+    const exactKey = `${file.folderId ?? 'root'}:${file.name.toLowerCase()}`
+    const localNameKey = `${file.folderId ?? 'root'}:${localFileName(file.name, file.type).toLowerCase()}`
+    byNameAndParent.set(exactKey, preferLocalFileMatch(byNameAndParent.get(exactKey), file))
+    byNameAndParent.set(localNameKey, preferLocalFileMatch(byNameAndParent.get(localNameKey), file))
   }
   const folderByDriveId = new Map(localFolders.filter((folder) => folder.driveFolderId).map((folder) => [folder.driveFolderId as string, folder]))
   const seenDriveFileIds = new Set<string>()


### PR DESCRIPTION
## Summary
- Sync Drive backup folders/files into local storage on startup so files created on another device appear after sync.
- Merge imported Drive files into matching local records and de-duplicate logical files in Recent/Library.
- Simplify file status wording to Saving/Saved/Syncing/Synced/Sync paused and remove confusing Drive file existence UI.
- Hide backup/import extensions like .mybook.md, .md, .docx, and .xlsx from app-visible names.

## Checks
- npm run lint (passes with existing Fast Refresh warnings)
- npm run typecheck
- npm test -- --run
- npm run build (passes with existing bundle-size warnings)