### PR TITLE
Fix library file and folder workflows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from 'react-router-dom'
 import { useEffect } from 'react'
 
 import { PwaStatus } from '../components/common/PwaStatus'
+import { Toaster } from '../components/ui/toast'
 import { TooltipProvider } from '../components/ui/tooltip'
 import { useAuthStore } from '../stores/useAuthStore'
 import { router } from './router'
@@ -17,6 +18,7 @@ export function App() {
     <TooltipProvider>
       <PwaStatus />
       <RouterProvider router={router} />
+      <Toaster />
     </TooltipProvider>
   </>
 }

--- a/src/components/common/AppButton.tsx
+++ b/src/components/common/AppButton.tsx
@@ -9,6 +9,7 @@ interface AppButtonProps extends Omit<ShadcnButtonProps, 'disabled' | 'onClick' 
   fullWidth?: boolean
   isDisabled?: boolean
   isLoading?: boolean
+  loadingLabel?: string
   onPress?: () => void
   variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'outline' | 'link'
 }
@@ -28,6 +29,7 @@ export function AppButton({
   fullWidth = false,
   isDisabled = false,
   isLoading = false,
+  loadingLabel = 'Loading...',
   onPress,
   variant = 'primary',
   ...props
@@ -40,7 +42,7 @@ export function AppButton({
       variant={variantMap[variant]}
       {...props}
     >
-      {isLoading ? 'Loading...' : children}
+      {isLoading ? loadingLabel : children}
     </Button>
   )
 }

--- a/src/components/document-editor/BlockActionsMenu.tsx
+++ b/src/components/document-editor/BlockActionsMenu.tsx
@@ -10,7 +10,16 @@ import type { Editor } from '@tiptap/react'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { NodeSelection } from '@tiptap/pm/state'
 import { useEffect, useState, type ReactNode } from 'react'
+import { AppButton } from '../common/AppButton'
 import { MobileBottomSheet } from '../common/MobileBottomSheet'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
 
 const actionableBlocks = new Set(['callout', 'toggleBlock', 'imageBlock', 'fileAttachment', 'table', 'blockquote', 'codeBlock'])
 
@@ -147,6 +156,7 @@ function SheetActionButton({
 
 export function BlockActionsMenu({ editor }: { editor: Editor }) {
   const [target, setTarget] = useState<BlockTarget | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<BlockTarget | null>(null)
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false)
 
   useEffect(() => {
@@ -168,40 +178,48 @@ export function BlockActionsMenu({ editor }: { editor: Editor }) {
     }
   }, [editor])
 
-  if (!target) return null
+  if (!target && !deleteTarget) return null
 
-  const previous = editor.state.doc.resolve(target.pos).nodeBefore
-  const next = editor.state.doc.resolve(target.pos + target.node.nodeSize).nodeAfter
-  const top = Math.max(88, target.rect.top)
-  const left = Math.max(8, Math.min(target.rect.left - 52, window.innerWidth - 188))
+  const previous = target ? editor.state.doc.resolve(target.pos).nodeBefore : null
+  const next = target ? editor.state.doc.resolve(target.pos + target.node.nodeSize).nodeAfter : null
+  const top = target ? Math.max(88, target.rect.top) : 88
+  const left = target ? Math.max(8, Math.min(target.rect.left - 52, window.innerWidth - 188)) : 8
 
   const runMobileAction = (action: () => void) => {
     action()
     setIsMobileSheetOpen(false)
   }
 
+  const requestDeleteBlock = (blockTarget: BlockTarget) => {
+    setDeleteTarget(blockTarget)
+    setIsMobileSheetOpen(false)
+  }
+
   return (
     <>
-      <div
-        className="fixed z-40 hidden gap-1 rounded-[8px] border border-[var(--app-border)] bg-[var(--app-surface)] p-1 shadow-[0_12px_32px_rgba(0,0,0,0.12)] md:flex"
-        style={{ top, left }}
-        role="toolbar"
-        aria-label="Block actions"
-      >
-        <ActionButton label="Move block up" disabled={!previous} onClick={() => moveBlockUp(editor, target)}>
-          <ArrowUpIcon aria-hidden="true" className="size-4" />
-        </ActionButton>
-        <ActionButton label="Move block down" disabled={!next} onClick={() => moveBlockDown(editor, target)}>
-          <ArrowDownIcon aria-hidden="true" className="size-4" />
-        </ActionButton>
-        <ActionButton label="Duplicate block" onClick={() => duplicateBlock(editor, target)}>
-          <DocumentDuplicateIcon aria-hidden="true" className="size-4" />
-        </ActionButton>
-        <ActionButton label="Delete block" onClick={() => deleteBlock(editor, target)}>
-          <TrashIcon aria-hidden="true" className="size-4" />
-        </ActionButton>
-      </div>
+      {target ? (
+        <div
+          className="fixed z-40 hidden gap-1 rounded-[8px] border border-[var(--app-border)] bg-[var(--app-surface)] p-1 shadow-[0_12px_32px_rgba(0,0,0,0.12)] md:flex"
+          style={{ top, left }}
+          role="toolbar"
+          aria-label="Block actions"
+        >
+          <ActionButton label="Move block up" disabled={!previous} onClick={() => moveBlockUp(editor, target)}>
+            <ArrowUpIcon aria-hidden="true" className="size-4" />
+          </ActionButton>
+          <ActionButton label="Move block down" disabled={!next} onClick={() => moveBlockDown(editor, target)}>
+            <ArrowDownIcon aria-hidden="true" className="size-4" />
+          </ActionButton>
+          <ActionButton label="Duplicate block" onClick={() => duplicateBlock(editor, target)}>
+            <DocumentDuplicateIcon aria-hidden="true" className="size-4" />
+          </ActionButton>
+          <ActionButton label="Delete block" onClick={() => requestDeleteBlock(target)}>
+            <TrashIcon aria-hidden="true" className="size-4" />
+          </ActionButton>
+        </div>
+      ) : null}
 
+      {target ? (
       <div className="fixed right-4 z-40 md:hidden" style={{ bottom: 'calc(var(--mybook-keyboard-offset, 0px) + 5.5rem + env(safe-area-inset-bottom))' }}>
         <MobileBottomSheet
           title="Block actions"
@@ -225,12 +243,39 @@ export function BlockActionsMenu({ editor }: { editor: Editor }) {
             <SheetActionButton label="Duplicate block" onClick={() => runMobileAction(() => duplicateBlock(editor, target))}>
               <DocumentDuplicateIcon aria-hidden="true" className="size-5 shrink-0" />
             </SheetActionButton>
-            <SheetActionButton label="Delete block" destructive onClick={() => runMobileAction(() => deleteBlock(editor, target))}>
+            <SheetActionButton label="Delete block" destructive onClick={() => requestDeleteBlock(target)}>
               <TrashIcon aria-hidden="true" className="size-5 shrink-0" />
             </SheetActionButton>
           </div>
         </MobileBottomSheet>
       </div>
+      ) : null}
+
+      <Dialog open={Boolean(deleteTarget)} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <div className="mb-2 flex size-11 items-center justify-center rounded-2xl bg-destructive/10 text-destructive">
+              <TrashIcon aria-hidden="true" className="size-6" />
+            </div>
+            <DialogTitle>Delete this block?</DialogTitle>
+            <DialogDescription>
+              This content will be removed from the document.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <AppButton variant="secondary" onPress={() => setDeleteTarget(null)}>Cancel</AppButton>
+            <AppButton
+              variant="danger"
+              onPress={() => {
+                if (deleteTarget) deleteBlock(editor, deleteTarget)
+                setDeleteTarget(null)
+              }}
+            >
+              Delete block
+            </AppButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/src/components/document-editor/TiptapDocumentEditor.tsx
+++ b/src/components/document-editor/TiptapDocumentEditor.tsx
@@ -12,10 +12,13 @@ import { useNavigate } from 'react-router-dom'
 
 import { fileRepository } from '../../database/repositories'
 import { useAutosave } from '../../hooks/useAutosave'
+import { useLibraryData } from '../../hooks/useLibraryData'
 import { backupDocumentToDrive, copyDriveFileLink, openDriveFileInBrowser } from '../../services/googleDrive'
 import { documentToMyBookMarkdown, downloadMyBookMarkdown, myBookMarkdownToDocument } from '../../utils/mybookMarkdown'
 import { AppButton } from '../common/AppButton'
 import { EmptyState } from '../common/EmptyState'
+import { DeleteFileDialog } from '../files/DeleteFileDialog'
+import { FolderBreadcrumb } from '../files/FolderBreadcrumb'
 import { BlockActionsMenu } from './BlockActionsMenu'
 import { ChecklistActionsMenu } from './ChecklistActionsMenu'
 import { DocumentToolbar } from './DocumentToolbar'
@@ -27,6 +30,8 @@ import { ToggleBlock, toggleBlockNode } from './extensions/ToggleBlock'
 import { filterSlashCommands, runSlashCommand, SlashCommandMenu, type SlashMenuState } from './SlashCommandMenu'
 import { TableActionsMenu } from './TableActionsMenu'
 import { devLog } from '../../utils/safeLog'
+import { deletedToast } from '../../utils/deleteToast'
+import { toast } from '../ui/toast'
 
 const emptyDocument = { type: 'doc', content: [{ type: 'paragraph' }] }
 
@@ -99,6 +104,7 @@ function DesktopMenu({ label, children }: { label: string; children: ReactNode }
 
 export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
   const navigate = useNavigate()
+  const { folders } = useLibraryData()
   const file = useLiveQuery(async () => (await fileRepository.get(fileId)).data, [fileId])
   const { content, isHydrated, save, setContent, status } = useAutosave(file)
   const [title, setTitle] = useState('')
@@ -110,6 +116,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
   const [isFullWidth, setIsFullWidth] = useState(false)
   const [zoom, setZoom] = useState(100)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const importInputRef = useRef<HTMLInputElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
@@ -280,6 +287,21 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     setCloudMessage(result.success ? 'Backup link copied.' : result.error ?? 'Could not copy the backup link.')
   }
   const close = async () => { await saveAll(); navigate(file.folderId ? `/folders/${file.folderId}` : '/home') }
+  const deleteDocument = async () => {
+    await saveAll()
+    const result = await fileRepository.delete(file.id)
+    if (!result.success) return
+    navigate(file.folderId ? `/folders/${file.folderId}` : '/home')
+    toast.add(deletedToast({
+      itemName: title || file.name,
+      onUndo: () => { void fileRepository.restore(file.id) },
+    }))
+  }
+  const duplicateDocument = async () => {
+    await saveAll()
+    const result = await fileRepository.duplicate(file.id)
+    if (result.data) navigate(`/document/${result.data.id}`)
+  }
 
   const setEditorLink = () => {
     const current = editor.getAttributes('link').href as string | undefined
@@ -390,6 +412,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     else if (action === 'prepare-docx') void exportDocx(false)
     else if (action === 'open-drive' && file.driveFileId) void openDriveFileInBrowser(file.driveFileId)
     else if (action === 'import') importInputRef.current?.click()
+    else if (action === 'duplicate') void duplicateDocument()
     else if (action === 'undo') editor.chain().focus().undo().run()
     else if (action === 'redo') editor.chain().focus().redo().run()
     else if (action === 'clear') editor.chain().focus().unsetAllMarks().clearNodes().run()
@@ -417,6 +440,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     else if (action === 'page-width') setIsFullWidth(false)
     else if (action === 'full-width') setIsFullWidth(true)
     else if (action.startsWith('zoom-')) setZoom(Number(action.replace('zoom-', '')))
+    else if (action === 'delete') setIsDeleteDialogOpen(true)
     else void close()
   }
 
@@ -444,8 +468,11 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
             <EditorStatus status={status} />
             {cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}
             {file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}
+            <div className="mt-1">
+              <FolderBreadcrumb currentFolderId={file.folderId} folders={folders} currentPageLabel={title} onNavigate={navigate} />
+            </div>
           </div>
-          <Dropdown><Dropdown.Trigger aria-label="More document actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Document actions" onAction={handleDocumentAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item><Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item><Dropdown.Item id="prepare-docx">Prepare DOCX</Dropdown.Item><Dropdown.Item id="import">Import document</Dropdown.Item><Dropdown.Item id="close">Close document</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
+          <Dropdown><Dropdown.Trigger aria-label="More document actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Document actions" onAction={handleDocumentAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="duplicate">Duplicate</Dropdown.Item><Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item><Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item><Dropdown.Item id="prepare-docx">Prepare DOCX</Dropdown.Item><Dropdown.Item id="import">Import document</Dropdown.Item><Dropdown.Item id="delete" variant="danger">Move to Trash</Dropdown.Item><Dropdown.Item id="close">Close document</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
           <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void saveAll()}>Save</AppButton>
           <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Sync now</AppButton>
           <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open backup</AppButton>
@@ -456,9 +483,11 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
               <Dropdown.Item id="save">Save now</Dropdown.Item>
               <Dropdown.Item id="backup">Sync now</Dropdown.Item>
               <Dropdown.Item id="import">Import document</Dropdown.Item>
+              <Dropdown.Item id="duplicate">Duplicate</Dropdown.Item>
               <Dropdown.Item id="export-markdown">Export MyBook Markdown</Dropdown.Item>
               <Dropdown.Item id="download-docx">Download DOCX</Dropdown.Item>
               <Dropdown.Item id="prepare-docx">Prepare DOCX</Dropdown.Item>
+              <Dropdown.Item id="delete" variant="danger">Move to Trash</Dropdown.Item>
               <Dropdown.Item id="close">Close document</Dropdown.Item>
             </Dropdown.Menu>
           </DesktopMenu>
@@ -584,6 +613,12 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
       <ChecklistActionsMenu editor={editor} />
       <BlockActionsMenu editor={editor} />
       <DocumentToolbar editor={editor} onInsertFile={openFilePicker} onInsertImage={openImagePicker} variant="mobile" />
+      <DeleteFileDialog
+        isOpen={isDeleteDialogOpen}
+        fileName={title || file.name}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={() => { void deleteDocument() }}
+      />
     </section>
   )
 }

--- a/src/components/files/DeleteFileDialog.tsx
+++ b/src/components/files/DeleteFileDialog.tsx
@@ -3,16 +3,23 @@ import { useEffect, useRef } from 'react'
 
 import { AppButton } from '../common/AppButton'
 
-interface DeleteFolderDialogProps {
+interface DeleteFileDialogProps {
   isOpen: boolean
-  folderName: string
-  hasContents?: boolean
+  fileName: string
+  mode?: 'trash' | 'permanent'
   onClose: () => void
   onConfirm: () => void
 }
 
-export function DeleteFolderDialog({ isOpen, folderName, hasContents = false, onClose, onConfirm }: DeleteFolderDialogProps) {
+export function DeleteFileDialog({
+  isOpen,
+  fileName,
+  mode = 'trash',
+  onClose,
+  onConfirm,
+}: DeleteFileDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
+  const isPermanent = mode === 'permanent'
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -28,23 +35,27 @@ export function DeleteFolderDialog({ isOpen, folderName, hasContents = false, on
   return (
     <dialog
       ref={dialogRef}
-      aria-labelledby="delete-folder-title"
-      aria-describedby="delete-folder-description"
+      aria-labelledby="delete-file-title"
+      aria-describedby="delete-file-description"
       onCancel={(event) => { event.preventDefault(); close() }}
       onClose={onClose}
       className="m-auto w-[calc(100%-2rem)] max-w-md rounded-[14px] border border-[var(--app-border)] bg-[var(--app-surface)] p-0 text-foreground backdrop:bg-black/50"
     >
       <div className="p-5">
         <ExclamationTriangleIcon aria-hidden="true" className="size-7 text-danger" />
-        <h2 id="delete-folder-title" className="mt-3 text-lg font-semibold">Move "{folderName}" to Trash?</h2>
-        <p id="delete-folder-description" className="mt-2 text-base leading-7 text-muted-foreground">
-          {hasContents
-            ? 'This folder is not empty. Its files and nested folders will also be moved to Trash.'
-            : 'This folder will move to Trash. You can restore it later from Trash.'}
+        <h2 id="delete-file-title" className="mt-3 text-lg font-semibold">
+          {isPermanent ? `Delete "${fileName}" permanently?` : `Move "${fileName}" to Trash?`}
+        </h2>
+        <p id="delete-file-description" className="mt-2 text-base leading-7 text-muted-foreground">
+          {isPermanent
+            ? 'This file will be permanently deleted and cannot be restored.'
+            : 'This file will move to Trash, where you can restore it later.'}
         </p>
         <div className="mt-6 flex flex-wrap justify-end gap-2">
           <AppButton variant="secondary" onPress={close}>Cancel</AppButton>
-          <AppButton variant="danger" onPress={() => { onConfirm(); close() }}>Move to Trash</AppButton>
+          <AppButton variant="danger" onPress={() => { onConfirm(); close() }}>
+            {isPermanent ? 'Delete permanently' : 'Move to Trash'}
+          </AppButton>
         </div>
       </div>
     </dialog>

--- a/src/components/files/FolderBreadcrumb.test.tsx
+++ b/src/components/files/FolderBreadcrumb.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FolderBreadcrumb } from './FolderBreadcrumb'
+import type { MyBookFolder } from '../../types/files'
+
+const folders: MyBookFolder[] = [
+  {
+    id: 'folder-1',
+    driveFolderId: null,
+    name: 'Sharu',
+    parentId: null,
+    createdAt: '2026-08-29T00:00:00.000Z',
+    updatedAt: '2026-08-29T00:00:00.000Z',
+    isDeleted: false,
+  },
+  {
+    id: 'folder-2',
+    driveFolderId: null,
+    name: 'Inside sharu',
+    parentId: 'folder-1',
+    createdAt: '2026-08-29T00:00:00.000Z',
+    updatedAt: '2026-08-29T00:00:00.000Z',
+    isDeleted: false,
+  },
+]
+
+describe('FolderBreadcrumb', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows Library and the file for root-level files', () => {
+    render(<FolderBreadcrumb currentFolderId={null} folders={folders} currentPageLabel="chromebook" onNavigate={vi.fn()} />)
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'Folder path' })
+
+    expect(breadcrumb).toHaveTextContent('Library')
+    expect(breadcrumb).toHaveTextContent('chromebook')
+    expect(screen.getByRole('link', { current: 'page' })).toHaveTextContent('chromebook')
+  })
+
+  it('shows folder hierarchy with a file as the current page', () => {
+    const onNavigate = vi.fn()
+
+    render(<FolderBreadcrumb currentFolderId="folder-2" folders={folders} currentPageLabel="chromebook" onNavigate={onNavigate} />)
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'Folder path' })
+
+    expect(breadcrumb).toHaveTextContent('Library')
+    expect(breadcrumb).toHaveTextContent('Sharu')
+    expect(breadcrumb).toHaveTextContent('Inside sharu')
+    expect(breadcrumb).toHaveTextContent('chromebook')
+    expect(screen.getByRole('link', { current: 'page' })).toHaveTextContent('chromebook')
+
+    fireEvent.click(screen.getByRole('link', { name: 'Inside sharu' }))
+
+    expect(onNavigate).toHaveBeenCalledWith('/folders/folder-2')
+  })
+})

--- a/src/components/files/FolderBreadcrumb.tsx
+++ b/src/components/files/FolderBreadcrumb.tsx
@@ -1,0 +1,107 @@
+import { Fragment } from 'react'
+
+import type { MyBookFolder } from '../../types/files'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../ui/breadcrumb'
+
+interface FolderBreadcrumbProps {
+  currentFolderId: string | null
+  folders: MyBookFolder[]
+  includeCurrent?: boolean
+  currentPageLabel?: string
+  onNavigate: (path: string) => void
+}
+
+export function FolderBreadcrumb({
+  currentFolderId,
+  folders,
+  includeCurrent = true,
+  currentPageLabel,
+  onNavigate,
+}: FolderBreadcrumbProps) {
+  const path = currentFolderId ? getFolderPath(currentFolderId, folders) : []
+  const hasCurrentPage = Boolean(currentPageLabel?.trim())
+
+  return (
+    <Breadcrumb aria-label="Folder path" className="max-w-full overflow-hidden">
+      <BreadcrumbList className="max-w-full flex-nowrap overflow-x-auto whitespace-nowrap rounded-md pb-1 text-xs sm:text-sm">
+        <BreadcrumbItem>
+          {currentFolderId || hasCurrentPage ? (
+            <BreadcrumbLink
+              href="/folders"
+              onClick={(event) => {
+                event.preventDefault()
+                onNavigate('/folders')
+              }}
+              className="inline-flex min-h-8 max-w-24 items-center rounded-md px-1.5 text-muted-foreground hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] sm:max-w-36"
+            >
+              Library
+            </BreadcrumbLink>
+          ) : (
+            <BreadcrumbPage className="inline-flex min-h-8 max-w-24 items-center truncate px-1.5 font-medium text-foreground sm:max-w-36">
+              Library
+            </BreadcrumbPage>
+          )}
+        </BreadcrumbItem>
+        {path.map((folder, index) => {
+          const isCurrent = !hasCurrentPage && includeCurrent && index === path.length - 1
+
+          return (
+            <Fragment key={folder.id}>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem className="min-w-0">
+                {isCurrent ? (
+                  <BreadcrumbPage className="inline-flex min-h-8 max-w-32 items-center truncate px-1.5 font-medium text-foreground sm:max-w-56">
+                    {folder.name}
+                  </BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink
+                    href={`/folders/${folder.id}`}
+                    onClick={(event) => {
+                      event.preventDefault()
+                      onNavigate(`/folders/${folder.id}`)
+                    }}
+                    className="inline-flex min-h-8 max-w-32 items-center rounded-md px-1.5 text-muted-foreground hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] sm:max-w-56"
+                  >
+                    <span className="truncate">{folder.name}</span>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+            </Fragment>
+          )
+        })}
+        {hasCurrentPage ? (
+          <>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem className="min-w-0">
+              <BreadcrumbPage className="inline-flex min-h-8 max-w-32 items-center truncate px-1.5 font-medium text-foreground sm:max-w-56">
+                {currentPageLabel}
+              </BreadcrumbPage>
+            </BreadcrumbItem>
+          </>
+        ) : null}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+function getFolderPath(currentFolderId: string, folders: MyBookFolder[]) {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]))
+  const path: MyBookFolder[] = []
+  const visited = new Set<string>()
+  let cursor = byId.get(currentFolderId)
+
+  while (cursor && !visited.has(cursor.id)) {
+    path.unshift(cursor)
+    visited.add(cursor.id)
+    cursor = cursor.parentId ? byId.get(cursor.parentId) : undefined
+  }
+
+  return path
+}

--- a/src/components/files/FolderCard.test.tsx
+++ b/src/components/files/FolderCard.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { FolderCard } from './FolderCard'
+
+describe('FolderCard', () => {
+  it.each([
+    { fileCount: 0, folderCount: 0, label: 'Empty' },
+    { fileCount: 1, folderCount: 0, label: '1 file' },
+    { fileCount: 2, folderCount: 0, label: '2 files' },
+    { fileCount: 0, folderCount: 1, label: '1 folder' },
+    { fileCount: 0, folderCount: 2, label: '2 folders' },
+    { fileCount: 2, folderCount: 1, label: '2 files, 1 folder' },
+    { fileCount: 1, folderCount: 2, label: '1 file, 2 folders' },
+  ])('shows $label for folder contents', ({ fileCount, folderCount, label }) => {
+    render(<FolderCard name="Projects" fileCount={fileCount} folderCount={folderCount} />)
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+})

--- a/src/components/files/FolderCard.tsx
+++ b/src/components/files/FolderCard.tsx
@@ -2,13 +2,23 @@ import type { ReactNode } from 'react'
 
 interface FolderCardProps {
   name: string
-  itemCount: number
+  fileCount: number
+  folderCount: number
   driveStatus?: ReactNode
   onOpen?: () => void
   action?: ReactNode
 }
 
-export function FolderCard({ name, itemCount, driveStatus, onOpen, action }: FolderCardProps) {
+function formatFolderContents(fileCount: number, folderCount: number) {
+  const parts = []
+  if (fileCount > 0) parts.push(`${fileCount} ${fileCount === 1 ? 'file' : 'files'}`)
+  if (folderCount > 0) parts.push(`${folderCount} ${folderCount === 1 ? 'folder' : 'folders'}`)
+  return parts.length ? parts.join(', ') : 'Empty'
+}
+
+export function FolderCard({ name, fileCount, folderCount, driveStatus, onOpen, action }: FolderCardProps) {
+  const contentsLabel = formatFolderContents(fileCount, folderCount)
+
   return (
     <article className="flex min-h-[60px] items-center gap-3 border-b border-[var(--app-border)] px-3 py-2 transition-colors hover:bg-[var(--app-subtle)]">
       <button type="button" onClick={onOpen} className="flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left">
@@ -17,7 +27,7 @@ export function FolderCard({ name, itemCount, driveStatus, onOpen, action }: Fol
         </span>
         <span className="min-w-0">
           <span className="block truncate text-sm font-medium leading-5">{name}</span>
-          <span className="block text-xs leading-4 text-muted-foreground">{itemCount} {itemCount === 1 ? 'file' : 'files'}</span>
+          <span className="block text-xs leading-4 text-muted-foreground">{contentsLabel}</span>
           {driveStatus ? <span className="sr-only">{driveStatus}</span> : null}
         </span>
       </button>

--- a/src/components/files/FolderManagerView.test.tsx
+++ b/src/components/files/FolderManagerView.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { MouseEvent } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FolderManagerView } from './FolderManagerView'
+import { fileRepository, folderRepository } from '../../database/repositories'
+import { toast } from '../ui/toast'
+import type { MyBookFile, MyBookFolder } from '../../types/files'
+
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockLibraryData = vi.hoisted((): { files: MyBookFile[]; folders: MyBookFolder[] } => ({
+  files: [],
+  folders: [],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../../hooks/useLibraryData', () => ({
+  useLibraryData: () => ({ ...mockLibraryData, isLoading: false }),
+}))
+
+vi.mock('../../database/repositories', () => ({
+  fileRepository: {
+    delete: vi.fn(),
+    duplicate: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  },
+  folderRepository: {
+    create: vi.fn(),
+    delete: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+vi.mock('../ui/toast', () => ({
+  toast: {
+    add: vi.fn(),
+  },
+}))
+
+vi.mock('./CreateItemDrawer', () => ({
+  CreateItemDrawer: ({ onCreateFolder }: { onCreateFolder: () => void }) => (
+    <button type="button" onClick={onCreateFolder}>New folder</button>
+  ),
+}))
+
+vi.mock('./FileActionsMenu', () => ({
+  FileActionsMenu: ({ fileName, onDelete }: { fileName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete file {fileName}</button>
+  ),
+}))
+
+vi.mock('./FolderActionsMenu', () => ({
+  FolderActionsMenu: ({ folderName, onDelete }: { folderName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete folder {folderName}</button>
+  ),
+}))
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.open = true
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function close(this: HTMLDialogElement) {
+    this.open = false
+  })
+})
+
+describe('FolderManagerView folder creation', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockLibraryData.files = []
+    mockLibraryData.folders = []
+    vi.mocked(folderRepository.create).mockReset()
+    vi.mocked(folderRepository.delete).mockReset()
+    vi.mocked(folderRepository.restore).mockReset()
+    vi.mocked(fileRepository.delete).mockReset()
+    vi.mocked(fileRepository.restore).mockReset()
+    vi.mocked(fileRepository.delete).mockResolvedValue({ success: true })
+    vi.mocked(folderRepository.delete).mockResolvedValue({ success: true })
+    vi.mocked(toast.add).mockReset()
+  })
+
+  it('navigates into newly created folders and shows a success toast', async () => {
+    vi.mocked(folderRepository.create).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'folder-2',
+        driveFolderId: null,
+        name: 'Archive',
+        parentId: null,
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:00:00.000Z',
+        isDeleted: false,
+      },
+    })
+
+    render(<MemoryRouter><FolderManagerView folderId={null} /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New folder' }))
+    fireEvent.change(screen.getByLabelText('Folder name'), { target: { value: 'Archive' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/folders/folder-2'))
+    expect(toast.add).toHaveBeenCalledWith({
+      title: '"Archive" created',
+      type: 'success',
+      priority: 'low',
+    })
+  })
+
+  it('shows an accessible breadcrumb path for nested folders', () => {
+    mockLibraryData.folders = [
+      {
+        id: 'folder-1',
+        driveFolderId: null,
+        name: 'Sharu',
+        parentId: null,
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:00:00.000Z',
+        isDeleted: false,
+      },
+      {
+        id: 'folder-2',
+        driveFolderId: null,
+        name: 'Inside sharu',
+        parentId: 'folder-1',
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:00:00.000Z',
+        isDeleted: false,
+      },
+    ]
+
+    render(<MemoryRouter><FolderManagerView folderId="folder-2" /></MemoryRouter>)
+
+    const breadcrumb = screen.getByRole('navigation', { name: 'Folder path' })
+
+    expect(breadcrumb).toHaveTextContent('Library')
+    expect(breadcrumb).toHaveTextContent('Sharu')
+    expect(breadcrumb).toHaveTextContent('Inside sharu')
+    expect(screen.getByRole('link', { current: 'page' })).toHaveTextContent('Inside sharu')
+
+    fireEvent.click(screen.getByRole('link', { name: 'Sharu' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/folders/folder-1')
+  })
+
+  it('requires confirmation before deleting a file inside a folder', async () => {
+    mockLibraryData.folders = [{
+      id: 'folder-1',
+      driveFolderId: null,
+      name: 'Projects',
+      parentId: null,
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      isDeleted: false,
+    }]
+    mockLibraryData.files = [{
+      id: 'file-1',
+      driveFileId: null,
+      name: 'Notes',
+      type: 'document',
+      folderId: 'folder-1',
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><FolderManagerView folderId="folder-1" /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete file Notes' }))
+
+    expect(fileRepository.delete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Move "Notes" to Trash?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }))
+
+    await waitFor(() => expect(fileRepository.delete).toHaveBeenCalledWith('file-1'))
+    expect(toast.add).toHaveBeenCalledWith(expect.objectContaining({
+      title: '"Notes" deleted',
+      type: 'success',
+      priority: 'low',
+    }))
+
+    const toastArg = vi.mocked(toast.add).mock.calls.at(-1)?.[0]
+    toastArg?.actionProps?.onClick?.({} as MouseEvent<HTMLButtonElement>)
+    expect(fileRepository.restore).toHaveBeenCalledWith('file-1')
+  })
+
+  it('requires confirmation before deleting an empty folder', async () => {
+    mockLibraryData.folders = [{
+      id: 'folder-1',
+      driveFolderId: null,
+      name: 'Projects',
+      parentId: null,
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><FolderManagerView folderId={null} /></MemoryRouter>)
+
+    const [deleteButton] = screen.getAllByRole('button', { name: 'Delete folder Projects' })
+    expect(deleteButton).toBeDefined()
+    fireEvent.click(deleteButton!)
+
+    expect(folderRepository.delete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Move "Projects" to Trash?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }))
+
+    await waitFor(() => expect(folderRepository.delete).toHaveBeenCalledWith('folder-1'))
+    expect(toast.add).toHaveBeenCalledWith(expect.objectContaining({
+      title: '"Projects" deleted',
+      type: 'success',
+      priority: 'low',
+    }))
+
+    const toastArg = vi.mocked(toast.add).mock.calls.at(-1)?.[0]
+    toastArg?.actionProps?.onClick?.({} as MouseEvent<HTMLButtonElement>)
+    expect(folderRepository.restore).toHaveBeenCalledWith('folder-1')
+  })
+})

--- a/src/components/files/FolderManagerView.tsx
+++ b/src/components/files/FolderManagerView.tsx
@@ -5,13 +5,18 @@ import { useNavigate } from 'react-router-dom'
 import { fileRepository, folderRepository } from '../../database/repositories'
 import { useLibraryData } from '../../hooks/useLibraryData'
 import type { MyBookFile, MyBookFolder } from '../../types/files'
+import { formatUpdatedAt } from '../../utils/dateFormat'
+import { deletedToast } from '../../utils/deleteToast'
 import { AppButton } from '../common/AppButton'
 import { EmptyState } from '../common/EmptyState'
 import { PageHeader } from '../common/PageHeader'
-import { DeleteFolderDialog } from './DeleteFolderDialog'
+import { toast } from '../ui/toast'
 import { CreateItemDrawer } from './CreateItemDrawer'
+import { DeleteFileDialog } from './DeleteFileDialog'
+import { DeleteFolderDialog } from './DeleteFolderDialog'
 import { FileCard } from './FileCard'
 import { FileActionsMenu } from './FileActionsMenu'
+import { FolderBreadcrumb } from './FolderBreadcrumb'
 import { FileNameDialog } from './FileNameDialog'
 import { FolderActionsMenu } from './FolderActionsMenu'
 import { FolderCard } from './FolderCard'
@@ -28,9 +33,11 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
   const [renameTarget, setRenameTarget] = useState<MyBookFolder | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<MyBookFolder | null>(null)
   const [fileRenameTarget, setFileRenameTarget] = useState<MyBookFile | null>(null)
+  const [fileDeleteTarget, setFileDeleteTarget] = useState<MyBookFile | null>(null)
   const currentFolder = folderId ? folders.find((folder) => folder.id === folderId) : null
   const childFolders = folders.filter((folder) => folder.parentId === folderId)
   const childFiles = files.filter((file) => file.folderId === folderId)
+  const childFolderNames = childFolders.map((folder) => folder.name)
 
   if (folderId && !currentFolder) {
     return (
@@ -45,13 +52,27 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
   const itemCount = (targetId: string) =>
     folders.filter((folder) => folder.parentId === targetId).length +
     files.filter((file) => file.folderId === targetId).length
+  const folderCount = (targetId: string) => folders.filter((folder) => folder.parentId === targetId).length
+  const fileCount = (targetId: string) => files.filter((file) => file.folderId === targetId).length
 
-  const requestDelete = (folder: MyBookFolder) => {
-    if (itemCount(folder.id) > 0) setDeleteTarget(folder)
-    else {
-      void folderRepository.delete(folder.id)
-      if (folder.id === folderId) navigate(folder.parentId ? `/folders/${folder.parentId}` : '/folders')
-    }
+  const deleteFile = (file: MyBookFile) => {
+    void fileRepository.delete(file.id).then((result) => {
+      if (!result.success) return
+      toast.add(deletedToast({
+        itemName: file.name,
+        onUndo: () => { void fileRepository.restore(file.id) },
+      }))
+    })
+  }
+
+  const deleteFolder = (folder: MyBookFolder) => {
+    void folderRepository.delete(folder.id).then((result) => {
+      if (!result.success) return
+      toast.add(deletedToast({
+        itemName: folder.name,
+        onUndo: () => { void folderRepository.restore(folder.id) },
+      }))
+    })
   }
 
   return (
@@ -77,7 +98,7 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
               currentParentId={currentFolder.parentId}
               onRename={() => setRenameTarget(currentFolder)}
               onMove={(destination) => void folderRepository.update(currentFolder.id, { parentId: destination })}
-              onDelete={() => requestDelete(currentFolder)}
+              onDelete={() => setDeleteTarget(currentFolder)}
             />
           </div>
         ) : (
@@ -92,12 +113,18 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
         )}
       />
 
+      {currentFolder ? (
+        <div className="mt-2 -mx-1 px-1">
+          <FolderBreadcrumb currentFolderId={currentFolder.id} folders={folders} onNavigate={navigate} />
+        </div>
+      ) : null}
+
       <div className="-mx-4 mt-4 px-1">
         {childFiles.map((file) => (
           <FileCard
             key={file.id}
             name={file.name}
-            meta={`Updated ${new Date(file.updatedAt).toLocaleDateString([], { month: 'short', day: 'numeric' })}`}
+            meta={`Updated ${formatUpdatedAt(file.updatedAt)}`}
             type={file.type}
             syncStatus={file.syncStatus}
             folderName={currentFolder?.name ?? 'MyBook'}
@@ -110,7 +137,7 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
                 onRename={() => setFileRenameTarget(file)}
                 onDuplicate={() => void fileRepository.duplicate(file.id)}
                 onMove={(destination) => void fileRepository.update(file.id, { folderId: destination })}
-                onDelete={() => void fileRepository.delete(file.id)}
+                onDelete={() => setFileDeleteTarget(file)}
               />
             }
           />
@@ -119,7 +146,8 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
           <FolderCard
             key={folder.id}
             name={folder.name}
-            itemCount={itemCount(folder.id)}
+            fileCount={fileCount(folder.id)}
+            folderCount={folderCount(folder.id)}
             driveStatus={folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
             onOpen={() => navigate(`/folders/${folder.id}`)}
             action={
@@ -130,7 +158,7 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
                 currentParentId={folder.parentId}
                 onRename={() => setRenameTarget(folder)}
                 onMove={(destination) => void folderRepository.update(folder.id, { parentId: destination })}
-                onDelete={() => requestDelete(folder)}
+                onDelete={() => setDeleteTarget(folder)}
               />
             }
           />
@@ -153,7 +181,14 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
         title="Create folder"
         submitLabel="Create"
         onClose={() => setIsCreating(false)}
+        existingFolderNames={childFolderNames}
         onSubmit={(name) => folderRepository.create(name, folderId)}
+        onSuccess={(result) => {
+          if (result.data) {
+            navigate(`/folders/${result.data.id}`)
+            toast.add({ title: `"${result.data.name}" created`, type: 'success', priority: 'low' })
+          }
+        }}
       />
       <FolderNameDialog
         isOpen={Boolean(renameTarget)}
@@ -161,18 +196,31 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
         submitLabel="Save"
         initialName={renameTarget?.name}
         onClose={() => setRenameTarget(null)}
+        existingFolderNames={folders
+          .filter((folder) => folder.parentId === renameTarget?.parentId && folder.id !== renameTarget?.id)
+          .map((folder) => folder.name)}
         onSubmit={(name) => renameTarget ? folderRepository.update(renameTarget.id, { name }) : Promise.resolve({ success: false })}
       />
       <DeleteFolderDialog
         isOpen={Boolean(deleteTarget)}
         folderName={deleteTarget?.name ?? ''}
+        hasContents={deleteTarget ? itemCount(deleteTarget.id) > 0 : false}
         onClose={() => setDeleteTarget(null)}
         onConfirm={() => {
           if (!deleteTarget) return
           const deletingCurrent = deleteTarget.id === folderId
           const destination = deleteTarget.parentId
-          void folderRepository.delete(deleteTarget.id)
+          deleteFolder(deleteTarget)
           if (deletingCurrent) navigate(destination ? `/folders/${destination}` : '/folders')
+        }}
+      />
+      <DeleteFileDialog
+        isOpen={Boolean(fileDeleteTarget)}
+        fileName={fileDeleteTarget?.name ?? ''}
+        onClose={() => setFileDeleteTarget(null)}
+        onConfirm={() => {
+          if (!fileDeleteTarget) return
+          deleteFile(fileDeleteTarget)
         }}
       />
       <FileNameDialog fileName={fileRenameTarget?.name ?? ''} isOpen={Boolean(fileRenameTarget)} onClose={() => setFileRenameTarget(null)} onSubmit={(name) => fileRenameTarget ? fileRepository.update(fileRenameTarget.id, { name }) : Promise.resolve({ success: false })} />

--- a/src/components/files/FolderNameDialog.test.tsx
+++ b/src/components/files/FolderNameDialog.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { FolderNameDialog } from './FolderNameDialog'
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.open = true
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function close(this: HTMLDialogElement) {
+    this.open = false
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('FolderNameDialog', () => {
+  it('shows duplicate folder names before submit', () => {
+    render(
+      <FolderNameDialog
+        isOpen
+        title="Create folder"
+        submitLabel="Create"
+        existingFolderNames={['Projects']}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Folder name'), { target: { value: ' projects ' } })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('"Projects" already exists. Use a different name.')
+    expect(screen.getByRole('alert')).toHaveClass('text-destructive')
+    expect(screen.getByRole('alert')).not.toHaveClass('bg-destructive/10')
+    expect(screen.getByLabelText('Folder name')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByLabelText('Folder name')).toHaveClass('aria-invalid:border-destructive')
+  })
+
+  it('does not show a duplicate error while a new folder is being submitted', async () => {
+    let resolveSubmit: (value: { success: boolean; data: { id: string; name: string } }) => void = () => {}
+    const submitPromise = new Promise<{ success: boolean; data: { id: string; name: string } }>((resolve) => {
+      resolveSubmit = resolve
+    })
+    const onClose = vi.fn()
+    const onSubmit = vi.fn(() => submitPromise)
+    const { rerender } = render(
+      <FolderNameDialog
+        isOpen
+        title="Create folder"
+        submitLabel="Create"
+        existingFolderNames={[]}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Folder name'), { target: { value: 'Projects' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Creating...' })).toBeDisabled())
+
+    rerender(
+      <FolderNameDialog
+        isOpen
+        title="Create folder"
+        submitLabel="Create"
+        existingFolderNames={['Projects']}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    resolveSubmit({ success: true, data: { id: 'folder-1', name: 'Projects' } })
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+})

--- a/src/components/files/FolderNameDialog.tsx
+++ b/src/components/files/FolderNameDialog.tsx
@@ -2,14 +2,23 @@ import { FolderIcon } from '@heroicons/react/24/outline'
 import { useEffect, useRef, useState } from 'react'
 
 import { AppButton } from '../common/AppButton'
+import { FieldError } from '../ui/field'
+
+type FolderNameDialogResult = {
+  success: boolean
+  error?: string
+  data?: { id: string; name: string } | void
+}
 
 interface FolderNameDialogProps {
   isOpen: boolean
   title: string
   submitLabel: string
   initialName?: string
+  existingFolderNames?: string[]
   onClose: () => void
-  onSubmit: (name: string) => Promise<{ success: boolean; error?: string }>
+  onSubmit: (name: string) => Promise<FolderNameDialogResult>
+  onSuccess?: (result: FolderNameDialogResult) => void
 }
 
 export function FolderNameDialog({
@@ -17,18 +26,29 @@ export function FolderNameDialog({
   title,
   submitLabel,
   initialName = '',
+  existingFolderNames = [],
   onClose,
   onSubmit,
+  onSuccess,
 }: FolderNameDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [name, setName] = useState(initialName)
   const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const normalizedName = cleanFolderName(name)
+  const duplicateFolderName = existingFolderNames.find((folderName) =>
+    cleanFolderName(folderName).toLocaleLowerCase() === normalizedName.toLocaleLowerCase()
+  )
+  const hasDuplicateName = normalizedName.length > 0 && Boolean(duplicateFolderName)
+  const validationError = hasDuplicateName ? `"${duplicateFolderName ?? normalizedName}" already exists. Use a different name.` : null
+  const displayedError = error ?? (isSubmitting ? null : validationError)
 
   useEffect(() => {
     const dialog = dialogRef.current
     if (isOpen && dialog && !dialog.open) {
       setName(initialName)
       setError(null)
+      setIsSubmitting(false)
       dialog.showModal()
     } else if (!isOpen && dialog?.open) {
       dialog.close()
@@ -56,9 +76,19 @@ export function FolderNameDialog({
         className="p-5"
         onSubmit={async (event) => {
           event.preventDefault()
+          if (!isSubmitting && validationError) {
+            setError(validationError)
+            return
+          }
+          setIsSubmitting(true)
           const result = await onSubmit(name)
-          if (result.success) close()
-          else setError(result.error ?? 'Unable to save this folder.')
+          if (result.success) {
+            close()
+            onSuccess?.(result)
+          } else {
+            setIsSubmitting(false)
+            setError(result.error ?? 'Unable to save this folder.')
+          }
         }}
       >
         <div className="flex items-center gap-3">
@@ -73,17 +103,22 @@ export function FolderNameDialog({
           onChange={(event) => {
             setName(event.target.value)
             setError(null)
+            setIsSubmitting(false)
           }}
-          aria-describedby={error ? 'folder-name-error' : undefined}
-          aria-invalid={Boolean(error)}
-          className="mt-2 min-h-11 w-full rounded-[10px] border border-[var(--app-border)] bg-background px-3 text-base"
+          aria-describedby={displayedError ? 'folder-name-error' : undefined}
+          aria-invalid={Boolean(displayedError)}
+          className="mt-2 min-h-11 w-full rounded-[10px] border border-[var(--app-border)] bg-background px-3 text-base outline-none aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20"
         />
-        {error ? <p id="folder-name-error" role="alert" className="mt-2 text-sm text-danger">{error}</p> : null}
+        {displayedError ? <FieldError id="folder-name-error" className="mt-2">{displayedError}</FieldError> : null}
         <div className="mt-6 flex flex-wrap justify-end gap-2">
           <AppButton type="button" variant="secondary" onPress={close}>Cancel</AppButton>
-          <AppButton type="submit" variant="primary">{submitLabel}</AppButton>
+          <AppButton type="submit" variant="primary" isLoading={isSubmitting} loadingLabel="Creating...">{submitLabel}</AppButton>
         </div>
       </form>
     </dialog>
   )
+}
+
+function cleanFolderName(value: string) {
+  return value.trim().replace(/\s+/g, ' ')
 }

--- a/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
+++ b/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
@@ -10,11 +10,16 @@ import { useNavigate } from 'react-router-dom'
 
 import { fileRepository } from '../../database/repositories'
 import { useAutosave } from '../../hooks/useAutosave'
+import { useLibraryData } from '../../hooks/useLibraryData'
 import { backupSpreadsheetToDrive, copyDriveFileLink, openDriveFileInBrowser } from '../../services/googleDrive'
 import type { UniverWorkbookSnapshot, XlsxResult } from '../../utils/xlsx'
 import { AppButton } from '../common/AppButton'
 import { EmptyState } from '../common/EmptyState'
 import { EditorStatus } from '../document-editor/EditorStatus'
+import { DeleteFileDialog } from '../files/DeleteFileDialog'
+import { FolderBreadcrumb } from '../files/FolderBreadcrumb'
+import { toast } from '../ui/toast'
+import { deletedToast } from '../../utils/deleteToast'
 
 function workbookData(content: string, id: string, name: string) {
   if (content) {
@@ -25,6 +30,7 @@ function workbookData(content: string, id: string, name: string) {
 
 export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   const navigate = useNavigate()
+  const { folders } = useLibraryData()
   const containerRef = useRef<HTMLDivElement>(null)
   const importInputRef = useRef<HTMLInputElement>(null)
   const workbookRef = useRef<{ save: () => object } | null>(null)
@@ -38,6 +44,7 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   const [xlsxWarnings, setXlsxWarnings] = useState<string[]>([])
   const [isConverting, setIsConverting] = useState(false)
   const [cloudMessage, setCloudMessage] = useState<string | null>(null)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const cloudTimerRef = useRef<number | null>(null)
   const cloudFlightRef = useRef(false)
   const latestSnapshot = useRef('')
@@ -127,6 +134,21 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   if (!file || file.isDeleted) return <EmptyState title="Spreadsheet not found" description="This spreadsheet may have been moved to Trash or deleted." />
 
   const close = async () => { await save(); navigate(file.folderId ? `/folders/${file.folderId}` : '/home') }
+  const deleteSpreadsheet = async () => {
+    await save()
+    const result = await fileRepository.delete(file.id)
+    if (!result.success) return
+    navigate(file.folderId ? `/folders/${file.folderId}` : '/home')
+    toast.add(deletedToast({
+      itemName: file.name,
+      onUndo: () => { void fileRepository.restore(file.id) },
+    }))
+  }
+  const duplicateSpreadsheet = async () => {
+    await save()
+    const result = await fileRepository.duplicate(file.id)
+    if (result.data) navigate(`/spreadsheet/${result.data.id}`)
+  }
 
   const makeXlsx = async (shouldDownload: boolean) => {
     const snapshot = workbookRef.current?.save() as UniverWorkbookSnapshot | undefined
@@ -196,8 +218,10 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     if (key === 'open-drive' && file?.driveFileId) void openDriveFileInBrowser(file.driveFileId)
     if (key === 'download-local') void makeXlsx(true)
     if (key === 'import') importInputRef.current?.click()
+    if (key === 'duplicate') void duplicateSpreadsheet()
     if (key === 'export') void makeXlsx(false)
     if (key === 'download') void makeXlsx(true)
+    if (key === 'delete') setIsDeleteDialogOpen(true)
     if (key === 'close') void close()
   }
 
@@ -205,8 +229,8 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     <section className="-mx-4 -my-6 flex min-h-0 flex-col sm:-mx-6 lg:-mx-8" style={{ height: editorHeight }}>
       <header className="z-30 flex min-h-16 shrink-0 items-center gap-2 border-b border-[var(--app-border)] bg-background px-2 sm:px-4">
         <button type="button" onClick={() => void close()} aria-label="Close spreadsheet" className="flex size-11 shrink-0 items-center justify-center rounded-[10px]"><ArrowLeftIcon aria-hidden="true" className="size-5" /></button>
-        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={status} />{cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}{file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}</div>
-        <Dropdown><Dropdown.Trigger aria-label="More spreadsheet actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Spreadsheet actions" onAction={handleMenuAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="download-local">Download local copy</Dropdown.Item><Dropdown.Item id="import"><span className="flex items-center gap-2"><ArrowUpTrayIcon aria-hidden="true" className="size-5" />Import XLSX</span></Dropdown.Item><Dropdown.Item id="export">Export XLSX</Dropdown.Item><Dropdown.Item id="download"><span className="flex items-center gap-2"><ArrowDownTrayIcon aria-hidden="true" className="size-5" />Download XLSX</span></Dropdown.Item><Dropdown.Item id="close">Close spreadsheet</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
+        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={status} />{cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}{file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}<div className="mt-1"><FolderBreadcrumb currentFolderId={file.folderId} folders={folders} currentPageLabel={file.name} onNavigate={navigate} /></div></div>
+        <Dropdown><Dropdown.Trigger aria-label="More spreadsheet actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Spreadsheet actions" onAction={handleMenuAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="duplicate">Duplicate</Dropdown.Item><Dropdown.Item id="download-local">Download local copy</Dropdown.Item><Dropdown.Item id="import"><span className="flex items-center gap-2"><ArrowUpTrayIcon aria-hidden="true" className="size-5" />Import XLSX</span></Dropdown.Item><Dropdown.Item id="export">Export XLSX</Dropdown.Item><Dropdown.Item id="download"><span className="flex items-center gap-2"><ArrowDownTrayIcon aria-hidden="true" className="size-5" />Download XLSX</span></Dropdown.Item><Dropdown.Item id="delete" variant="danger">Move to Trash</Dropdown.Item><Dropdown.Item id="close">Close spreadsheet</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
         <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void save()}>Save</AppButton>
         <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Sync now</AppButton>
         <AppButton className="hidden sm:flex" variant="secondary" isDisabled={!file.driveFileId} onPress={() => file.driveFileId ? openDriveFileInBrowser(file.driveFileId) : undefined}>Open backup</AppButton>
@@ -220,6 +244,12 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
         </div>
       )}
       <div ref={containerRef} className="univer-mobile min-h-0 flex-1 overflow-hidden bg-white" role="region" aria-label="Spreadsheet editor. Use the spreadsheet toolbar and cell controls to edit." />
+      <DeleteFileDialog
+        isOpen={isDeleteDialogOpen}
+        fileName={file.name}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={() => { void deleteSpreadsheet() }}
+      />
     </section>
   )
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -191,7 +191,7 @@ function ToastList() {
           <ToastTitle />
           <ToastDescription />
         </div>
-        <ToastAction />
+        <ToastAction {...toastItem.actionProps} />
         <ToastClose />
       </ToastContent>
     </Toast>

--- a/src/database/repositories.test.ts
+++ b/src/database/repositories.test.ts
@@ -32,6 +32,26 @@ describe('IndexedDB repositories', () => {
     expect((await fileRepository.get(id)).data).toMatchObject({ name: 'Meeting Notes', content: 'local content', isDeleted: false })
   })
 
+  it('creates files with unique default names in the same folder', async () => {
+    const firstDocument = await fileRepository.create('document')
+    const secondDocument = await fileRepository.create('document')
+    const firstSpreadsheet = await fileRepository.create('spreadsheet')
+    const secondSpreadsheet = await fileRepository.create('spreadsheet')
+
+    expect(firstDocument.data?.name).toBe('Untitled Document')
+    expect(secondDocument.data?.name).toBe('Untitled Document 2')
+    expect(firstSpreadsheet.data?.name).toBe('Untitled Spreadsheet')
+    expect(secondSpreadsheet.data?.name).toBe('Untitled Spreadsheet 2')
+
+    const files = await fileRepository.list()
+    expect(files.map((file) => file.name).sort()).toEqual([
+      'Untitled Document',
+      'Untitled Document 2',
+      'Untitled Spreadsheet',
+      'Untitled Spreadsheet 2',
+    ])
+  })
+
   it('creates nested folders and queues offline Drive work', async () => {
     const parent = await folderRepository.create('Projects')
     const child = await folderRepository.create('2026', parent.data!.id)

--- a/src/database/repositories.ts
+++ b/src/database/repositories.ts
@@ -142,6 +142,17 @@ async function uniqueFileName(name: string, folderId: string | null, excludedId?
   return !files.some((file) => file.id !== excludedId && !file.isDeleted && file.folderId === folderId && appFileName(file.name, file.type).toLocaleLowerCase() === name.toLocaleLowerCase())
 }
 
+async function nextFileName(baseName: string, folderId: string | null) {
+  if (await uniqueFileName(baseName, folderId)) return baseName
+  let suffix = 2
+  let name = `${baseName} ${suffix}`
+  while (!(await uniqueFileName(name, folderId))) {
+    suffix += 1
+    name = `${baseName} ${suffix}`
+  }
+  return name
+}
+
 function logicalFileKeys(file: MyBookFile) {
   const nameKey = `${file.folderId ?? 'root'}:${file.type}:${appFileName(file.name, file.type).toLocaleLowerCase()}`
   return file.driveFileId ? [`drive:${file.driveFileId}`, `name:${nameKey}`] : [`name:${nameKey}`]
@@ -172,7 +183,8 @@ export const fileRepository = {
   async create(type: FileType, folderId: string | null = null): Promise<RepositoryResult<MyBookFile>> {
     try {
       const now = new Date().toISOString()
-      const file: MyBookFile = { id: crypto.randomUUID(), driveFileId: null, name: type === 'document' ? 'Untitled document' : 'Untitled spreadsheet', type, folderId, content: '', mimeType: type === 'document' ? 'application/x-mybook-document' : 'application/x-mybook-spreadsheet', createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: 'pending', isDeleted: false }
+      const name = await nextFileName(type === 'document' ? 'Untitled Document' : 'Untitled Spreadsheet', folderId)
+      const file: MyBookFile = { id: crypto.randomUUID(), driveFileId: null, name, type, folderId, content: '', mimeType: type === 'document' ? 'application/x-mybook-document' : 'application/x-mybook-spreadsheet', createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: 'pending', isDeleted: false }
       await db.files.add(file)
       await queueFileSync(file.id, 'create', navigator.onLine ? null : 'Offline. File will sync when you reconnect.')
       if (navigator.onLine) await processPendingDriveSync()
@@ -266,7 +278,7 @@ export const folderRepository = {
       const normalized = cleanName(name)
       if (!normalized) return { success: false, error: 'Folder name cannot be empty.' }
       const siblings = await db.folders.filter((folder) => !folder.isDeleted && folder.parentId === parentId).toArray()
-      if (siblings.some((folder) => folder.name.toLocaleLowerCase() === normalized.toLocaleLowerCase())) return { success: false, error: 'A folder with this name already exists here.' }
+      if (siblings.some((folder) => folder.name.toLocaleLowerCase() === normalized.toLocaleLowerCase())) return { success: false, error: `"${normalized}" already exists. Use a different name.` }
       let depth = 1
       let ancestorId = parentId
       while (ancestorId) {
@@ -317,7 +329,7 @@ export const folderRepository = {
       if (changes.name !== undefined) { const name = cleanName(changes.name); if (!name) return { success: false, error: 'Folder name cannot be empty.' }; changes = { ...changes, name } }
       const nextName = changes.name ?? folder.name
       const siblings = await db.folders.filter((item) => !item.isDeleted && item.id !== id && item.parentId === targetParentId).toArray()
-      if (siblings.some((item) => item.name.toLocaleLowerCase() === nextName.toLocaleLowerCase())) return { success: false, error: 'A folder with this name already exists here.' }
+      if (siblings.some((item) => item.name.toLocaleLowerCase() === nextName.toLocaleLowerCase())) return { success: false, error: `"${nextName}" already exists. Use a different name.` }
       const next = { ...changes, updatedAt: new Date().toISOString() }
       await db.folders.update(id, next)
       if (changes.name !== undefined || changes.parentId !== undefined) {
@@ -345,13 +357,47 @@ export const folderRepository = {
     } catch (error) { return failure(error, 'Could not delete folder.') }
   },
   async restore(id: string) {
-    const result = await this.update(id, { isDeleted: false })
-    const folder = await db.folders.get(id)
-    if (result.success && folder) {
-      await queueFolderSync(id, folder.driveFolderId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. Folder restore will sync when you reconnect.')
-      if (navigator.onLine) await processPendingDriveFolderSync()
+    try {
+      let restoredFolderIds: string[] = []
+      let restoredFileIds: string[] = []
+      await db.transaction('rw', db.folders, db.files, async () => {
+        const folder = await db.folders.get(id)
+        if (!folder) throw new Error('Folder could not be found.')
+        const allFolders = await db.folders.toArray()
+        const ids = new Set([id])
+        let changed = true
+        while (changed) {
+          changed = false
+          allFolders.forEach((candidate) => {
+            if (candidate.parentId && ids.has(candidate.parentId) && !ids.has(candidate.id)) {
+              ids.add(candidate.id)
+              changed = true
+            }
+          })
+        }
+        restoredFolderIds = [...ids]
+        const now = new Date().toISOString()
+        await Promise.all(restoredFolderIds.map((folderId) => db.folders.update(folderId, { isDeleted: false, updatedAt: now })))
+        const nestedFiles = await db.files.filter((file) => Boolean(file.folderId && ids.has(file.folderId))).toArray()
+        restoredFileIds = nestedFiles.map((file) => file.id)
+        await Promise.all(restoredFileIds.map((fileId) => db.files.update(fileId, { isDeleted: false, updatedAt: now })))
+      })
+      const restoredFolders = await db.folders.bulkGet(restoredFolderIds)
+      await Promise.all(restoredFolders
+        .filter((folder): folder is MyBookFolder => Boolean(folder))
+        .map((folder) => queueFolderSync(folder.id, folder.driveFolderId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. Folder restore will sync when you reconnect.')))
+      const restoredFiles = await db.files.bulkGet(restoredFileIds)
+      await Promise.all(restoredFiles
+        .filter((file): file is MyBookFile => Boolean(file))
+        .map((file) => queueFileSync(file.id, file.driveFileId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. File restore will sync when you reconnect.')))
+      if (navigator.onLine) {
+        await processPendingDriveFolderSync()
+        await processPendingDriveSync()
+      }
+      return { success: true }
+    } catch (error) {
+      return failure(error, 'Could not restore folder.')
     }
-    return result
   },
   async list(): Promise<MyBookFolder[]> { try { return await db.folders.filter((folder) => !folder.isDeleted).toArray() } catch (error) { devLog('error', 'Could not list folders.', error); return [] } },
   async search(query: string): Promise<MyBookFolder[]> { try { const value = query.trim().toLocaleLowerCase(); return await db.folders.filter((folder) => !folder.isDeleted && folder.name.toLocaleLowerCase().includes(value)).toArray() } catch (error) { devLog('error', 'Could not search folders.', error); return [] } },

--- a/src/pages/DesignSystemPage.tsx
+++ b/src/pages/DesignSystemPage.tsx
@@ -54,8 +54,8 @@ export function DesignSystemPage() {
 
       <PreviewSection title="Files and folders">
         <div className="grid gap-3 sm:grid-cols-2">
-          <FolderCard name="Project notes" itemCount={8} />
-          <FolderCard name="Reading list" itemCount={1} />
+          <FolderCard name="Project notes" fileCount={8} folderCount={2} />
+          <FolderCard name="Reading list" fileCount={1} folderCount={0} />
           <FileCard name="Product brief" meta="Edited 12 minutes ago" action={<IconButton label="More actions for Product brief" variant="ghost"><EllipsisHorizontalIcon className="size-5" /></IconButton>} />
           <FileCard name="Research notes" meta="Document · 3 pages" />
         </div>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { MouseEvent } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HomePage } from './HomePage'
+import { fileRepository, folderRepository } from '../database/repositories'
+import { toast } from '../components/ui/toast'
+import type { MyBookFile, MyBookFolder } from '../types/files'
+
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockLibraryData = vi.hoisted((): { files: MyBookFile[]; folders: MyBookFolder[]; isLoading: boolean } => ({
+  files: [],
+  folders: [],
+  isLoading: false,
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../hooks/useLibraryData', () => ({
+  useLibraryData: () => mockLibraryData,
+}))
+
+vi.mock('../database/repositories', () => ({
+  fileRepository: {
+    create: vi.fn(),
+    delete: vi.fn(),
+    duplicate: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  },
+  folderRepository: {
+    create: vi.fn(),
+  },
+}))
+
+vi.mock('../components/ui/toast', () => ({
+  toast: {
+    add: vi.fn(),
+  },
+}))
+
+vi.mock('../components/files/CreateItemDrawer', () => ({
+  CreateItemDrawer: ({ onCreateFolder }: { onCreateFolder: () => void }) => (
+    <button type="button" onClick={onCreateFolder}>New folder</button>
+  ),
+}))
+
+vi.mock('../components/files/FileActionsMenu', () => ({
+  FileActionsMenu: ({ fileName, onDelete }: { fileName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete file {fileName}</button>
+  ),
+}))
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.open = true
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function close(this: HTMLDialogElement) {
+    this.open = false
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('HomePage folder creation', () => {
+  beforeEach(() => {
+    mockLibraryData.files = []
+    mockLibraryData.folders = []
+    mockNavigate.mockClear()
+    vi.clearAllMocks()
+    vi.mocked(fileRepository.delete).mockResolvedValue({ success: true })
+  })
+
+  it('closes the dialog, navigates into the new folder, and shows a success toast', async () => {
+    vi.mocked(folderRepository.create).mockResolvedValue({
+      success: true,
+      data: {
+        id: 'folder-1',
+        driveFolderId: null,
+        name: 'Projects',
+        parentId: null,
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:00:00.000Z',
+        isDeleted: false,
+      },
+    })
+
+    render(<MemoryRouter><HomePage /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New folder' }))
+    fireEvent.change(screen.getByLabelText('Folder name'), { target: { value: 'Projects' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/folders/folder-1'))
+    expect(toast.add).toHaveBeenCalledWith({
+      title: '"Projects" created',
+      type: 'success',
+      priority: 'low',
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('uses Recent-specific empty copy when there are no recent files', () => {
+    mockLibraryData.folders = [{
+      id: 'folder-1',
+      driveFolderId: null,
+      name: 'Projects',
+      parentId: null,
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><HomePage /></MemoryRouter>)
+
+    expect(screen.getByText('No recent files')).toBeInTheDocument()
+    expect(screen.getByText('Files you open or edit will appear here.')).toBeInTheDocument()
+    expect(screen.queryByText('No files yet')).not.toBeInTheDocument()
+  })
+
+  it('requires confirmation before deleting a recent file', async () => {
+    mockLibraryData.files = [{
+      id: 'file-1',
+      driveFileId: null,
+      name: 'Notes',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><HomePage /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete file Notes' }))
+
+    expect(fileRepository.delete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Move "Notes" to Trash?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }))
+
+    await waitFor(() => expect(fileRepository.delete).toHaveBeenCalledWith('file-1'))
+    expect(toast.add).toHaveBeenCalledWith(expect.objectContaining({
+      title: '"Notes" deleted',
+      type: 'success',
+      priority: 'low',
+    }))
+
+    const toastArg = vi.mocked(toast.add).mock.calls.at(-1)?.[0]
+    toastArg?.actionProps?.onClick?.({} as MouseEvent<HTMLButtonElement>)
+    expect(fileRepository.restore).toHaveBeenCalledWith('file-1')
+  })
+})

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,14 +4,18 @@ import { useNavigate } from 'react-router-dom'
 import { EmptyState } from '../components/common/EmptyState'
 import { PageHeader } from '../components/common/PageHeader'
 import { CreateItemDrawer } from '../components/files/CreateItemDrawer'
+import { DeleteFileDialog } from '../components/files/DeleteFileDialog'
 import { FileActionsMenu } from '../components/files/FileActionsMenu'
 import { FileCard } from '../components/files/FileCard'
 import { FileNameDialog } from '../components/files/FileNameDialog'
 import { FolderNameDialog } from '../components/files/FolderNameDialog'
+import { toast } from '../components/ui/toast'
 import { fileRepository, folderRepository } from '../database/repositories'
 import { useLibraryData } from '../hooks/useLibraryData'
 import type { MyBookFile } from '../types/files'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs'
+import { formatUpdatedAt } from '../utils/dateFormat'
+import { deletedToast } from '../utils/deleteToast'
 
 type HomeTab = 'recent' | 'favorites' | 'all'
 
@@ -20,9 +24,22 @@ export function HomePage() {
   const { files, folders } = useLibraryData()
   const [activeTab, setActiveTab] = useState<HomeTab>('recent')
   const [renameTarget, setRenameTarget] = useState<MyBookFile | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<MyBookFile | null>(null)
   const [isCreatingFolder, setIsCreatingFolder] = useState(false)
-  const recentFiles = [...files].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  const recentFiles = [...files].sort(compareFilesByUpdatedAt)
   const visibleFiles = activeTab === 'favorites' ? [] : activeTab === 'all' ? files : recentFiles
+  const rootFolderNames = folders.filter((folder) => folder.parentId === null).map((folder) => folder.name)
+  const emptyState = emptyHomeState(activeTab)
+
+  const deleteFile = (file: MyBookFile) => {
+    void fileRepository.delete(file.id).then((result) => {
+      if (!result.success) return
+      toast.add(deletedToast({
+        itemName: file.name,
+        onUndo: () => { void fileRepository.restore(file.id) },
+      }))
+    })
+  }
 
   const fileList = visibleFiles.length ? (
     <div className="px-1">
@@ -43,7 +60,7 @@ export function HomePage() {
               onRename={() => setRenameTarget(file)}
               onDuplicate={() => void fileRepository.duplicate(file.id)}
               onMove={(folderId) => void fileRepository.update(file.id, { folderId })}
-              onDelete={() => void fileRepository.delete(file.id)}
+              onDelete={() => setDeleteTarget(file)}
             />
           }
         />
@@ -52,8 +69,8 @@ export function HomePage() {
   ) : (
     <div className="px-4 pt-12">
       <EmptyState
-        title={activeTab === 'favorites' ? 'No favorite files yet' : 'No files yet'}
-        description={activeTab === 'favorites' ? 'Favorite files will appear here.' : 'Create a document or spreadsheet to get started.'}
+        title={emptyState.title}
+        description={emptyState.description}
       />
     </div>
   )
@@ -92,17 +109,51 @@ export function HomePage() {
         title="Create folder"
         submitLabel="Create"
         onClose={() => setIsCreatingFolder(false)}
+        existingFolderNames={rootFolderNames}
         onSubmit={(name) => folderRepository.create(name)}
+        onSuccess={(result) => {
+          if (result.data) {
+            navigate(`/folders/${result.data.id}`)
+            toast.add({ title: `"${result.data.name}" created`, type: 'success', priority: 'low' })
+          }
+        }}
+      />
+      <DeleteFileDialog
+        isOpen={Boolean(deleteTarget)}
+        fileName={deleteTarget?.name ?? ''}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          if (!deleteTarget) return
+          deleteFile(deleteTarget)
+        }}
       />
     </div>
   )
 }
 
-function formatUpdatedAt(value: string) {
-  const date = new Date(value)
-  const today = new Date()
-  if (date.toDateString() === today.toDateString()) {
-    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+function emptyHomeState(activeTab: HomeTab) {
+  if (activeTab === 'recent') {
+    return {
+      title: 'No recent files',
+      description: 'Files you open or edit will appear here.',
+    }
   }
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  if (activeTab === 'favorites') {
+    return {
+      title: 'No favorite files yet',
+      description: 'Favorite files will appear here.',
+    }
+  }
+  return {
+    title: 'No files yet',
+    description: 'Create a document or spreadsheet to get started.',
+  }
+}
+
+function compareFilesByUpdatedAt(a: MyBookFile, b: MyBookFile) {
+  const updated = b.updatedAt.localeCompare(a.updatedAt)
+  if (updated !== 0) return updated
+  const name = a.name.localeCompare(b.name, 'en-US', { sensitivity: 'base' })
+  if (name !== 0) return name
+  return a.id.localeCompare(b.id)
 }

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { MouseEvent } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SearchPage } from './SearchPage'
+import { fileRepository, folderRepository } from '../database/repositories'
+import { toast } from '../components/ui/toast'
+import type { MyBookFile, MyBookFolder } from '../types/files'
+
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockLibraryData = vi.hoisted((): { files: MyBookFile[]; folders: MyBookFolder[]; isLoading: boolean } => ({
+  files: [],
+  folders: [],
+  isLoading: false,
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../hooks/useLibraryData', () => ({
+  useLibraryData: () => mockLibraryData,
+}))
+
+vi.mock('../database/repositories', () => ({
+  fileRepository: {
+    delete: vi.fn(),
+    duplicate: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  },
+  folderRepository: {
+    delete: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+vi.mock('../components/ui/toast', () => ({
+  toast: {
+    add: vi.fn(),
+  },
+}))
+
+vi.mock('../components/files/FileActionsMenu', () => ({
+  FileActionsMenu: ({ fileName, onDelete }: { fileName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete file {fileName}</button>
+  ),
+}))
+
+vi.mock('../components/files/FolderActionsMenu', () => ({
+  FolderActionsMenu: ({ folderName, onDelete }: { folderName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete folder {folderName}</button>
+  ),
+}))
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.open = true
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function close(this: HTMLDialogElement) {
+    this.open = false
+  })
+})
+
+beforeEach(() => {
+  mockNavigate.mockClear()
+  mockLibraryData.files = []
+  mockLibraryData.folders = []
+  vi.clearAllMocks()
+  vi.mocked(fileRepository.delete).mockResolvedValue({ success: true })
+  vi.mocked(folderRepository.delete).mockResolvedValue({ success: true })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SearchPage', () => {
+  it('searches folders and navigates to matching folders', () => {
+    mockLibraryData.folders = [{
+      id: 'folder-1',
+      driveFolderId: null,
+      name: 'Projects',
+      parentId: null,
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><SearchPage /></MemoryRouter>)
+
+    fireEvent.change(screen.getByLabelText('Search files and folders'), { target: { value: 'proj' } })
+    fireEvent.click(screen.getByRole('button', { name: /ProjectsEmpty/ }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/folders/folder-1')
+  })
+
+  it('shows same-name file and folder results with distinct rows', () => {
+    mockLibraryData.files = [{
+      id: 'file-1',
+      driveFileId: null,
+      name: 'A folder',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    }]
+    mockLibraryData.folders = [
+      {
+        id: 'folder-1',
+        driveFolderId: null,
+        name: 'A folder',
+        parentId: null,
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:01:00.000Z',
+        isDeleted: false,
+      },
+      {
+        id: 'folder-child',
+        driveFolderId: null,
+        name: 'Child',
+        parentId: 'folder-1',
+        createdAt: '2026-08-29T00:00:00.000Z',
+        updatedAt: '2026-08-29T00:00:00.000Z',
+        isDeleted: false,
+      },
+    ]
+
+    render(<MemoryRouter><SearchPage /></MemoryRouter>)
+
+    fireEvent.change(screen.getByLabelText('Search files and folders'), { target: { value: 'a folder' } })
+
+    expect(screen.getAllByText('A folder')).toHaveLength(2)
+    expect(screen.getByText('1 folder')).toBeInTheDocument()
+    expect(screen.getByText('Updated Aug 22, 2026, 12:00 AM')).toBeInTheDocument()
+  })
+
+  it('shows a global empty state when no files or folders match', () => {
+    render(<MemoryRouter><SearchPage /></MemoryRouter>)
+
+    fireEvent.change(screen.getByLabelText('Search files and folders'), { target: { value: 'missing' } })
+
+    expect(screen.getByText('No files or folders found')).toBeInTheDocument()
+    expect(screen.getByText('Try another name.')).toBeInTheDocument()
+  })
+
+  it('requires confirmation before deleting search results', async () => {
+    mockLibraryData.files = [{
+      id: 'file-1',
+      driveFileId: null,
+      name: 'Archive note',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    }]
+    mockLibraryData.folders = [{
+      id: 'folder-1',
+      driveFolderId: null,
+      name: 'Archive',
+      parentId: null,
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      isDeleted: false,
+    }]
+
+    render(<MemoryRouter><SearchPage /></MemoryRouter>)
+
+    fireEvent.change(screen.getByLabelText('Search files and folders'), { target: { value: 'archive' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Delete file Archive note' }))
+
+    expect(fileRepository.delete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Move "Archive note" to Trash?')
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }))
+
+    await waitFor(() => expect(fileRepository.delete).toHaveBeenCalledWith('file-1'))
+    expect(toast.add).toHaveBeenCalledWith(expect.objectContaining({
+      title: '"Archive note" deleted',
+      type: 'success',
+      priority: 'low',
+    }))
+
+    let toastArg = vi.mocked(toast.add).mock.calls.at(-1)?.[0]
+    toastArg?.actionProps?.onClick?.({} as MouseEvent<HTMLButtonElement>)
+    expect(fileRepository.restore).toHaveBeenCalledWith('file-1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete folder Archive' }))
+
+    expect(folderRepository.delete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Move "Archive" to Trash?')
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }))
+
+    await waitFor(() => expect(folderRepository.delete).toHaveBeenCalledWith('folder-1'))
+    expect(toast.add).toHaveBeenCalledWith(expect.objectContaining({
+      title: '"Archive" deleted',
+      type: 'success',
+      priority: 'low',
+    }))
+
+    toastArg = vi.mocked(toast.add).mock.calls.at(-1)?.[0]
+    toastArg?.actionProps?.onClick?.({} as MouseEvent<HTMLButtonElement>)
+    expect(folderRepository.restore).toHaveBeenCalledWith('folder-1')
+  })
+})

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -4,26 +4,71 @@ import { useNavigate } from 'react-router-dom'
 import { EmptyState } from '../components/common/EmptyState'
 import { PageHeader } from '../components/common/PageHeader'
 import { SearchInput } from '../components/common/SearchInput'
+import { DeleteFileDialog } from '../components/files/DeleteFileDialog'
+import { DeleteFolderDialog } from '../components/files/DeleteFolderDialog'
 import { FileActionsMenu } from '../components/files/FileActionsMenu'
 import { FileCard } from '../components/files/FileCard'
 import { FileNameDialog } from '../components/files/FileNameDialog'
-import { fileRepository } from '../database/repositories'
+import { FolderActionsMenu } from '../components/files/FolderActionsMenu'
+import { FolderCard } from '../components/files/FolderCard'
+import { FolderNameDialog } from '../components/files/FolderNameDialog'
+import { fileRepository, folderRepository } from '../database/repositories'
 import { useLibraryData } from '../hooks/useLibraryData'
-import type { MyBookFile } from '../types/files'
+import type { MyBookFile, MyBookFolder } from '../types/files'
+import { formatUpdatedAt } from '../utils/dateFormat'
+import { deletedToast } from '../utils/deleteToast'
+import { toast } from '../components/ui/toast'
+
+type SearchResult =
+  | { kind: 'file'; item: MyBookFile }
+  | { kind: 'folder'; item: MyBookFolder }
 
 export function SearchPage() {
   const navigate = useNavigate()
   const { files, folders } = useLibraryData()
   const [query, setQuery] = useState('')
   const [renameTarget, setRenameTarget] = useState<MyBookFile | null>(null)
+  const [folderRenameTarget, setFolderRenameTarget] = useState<MyBookFolder | null>(null)
+  const [folderDeleteTarget, setFolderDeleteTarget] = useState<MyBookFolder | null>(null)
+  const [fileDeleteTarget, setFileDeleteTarget] = useState<MyBookFile | null>(null)
 
-  const visibleFiles = useMemo(() => {
+  const results = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase()
     if (!normalizedQuery) return []
-    return files
+    const matchingFiles: SearchResult[] = files
       .filter((file) => file.name.toLocaleLowerCase().includes(normalizedQuery))
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-  }, [files, query])
+      .map((item) => ({ kind: 'file', item }))
+    const matchingFolders: SearchResult[] = folders
+      .filter((folder) => folder.name.toLocaleLowerCase().includes(normalizedQuery))
+      .map((item) => ({ kind: 'folder', item }))
+    return [...matchingFiles, ...matchingFolders].sort(compareResultsByUpdatedAt)
+  }, [files, folders, query])
+
+  const itemCount = (targetId: string) =>
+    folders.filter((folder) => folder.parentId === targetId).length +
+    files.filter((file) => file.folderId === targetId).length
+  const folderCount = (targetId: string) => folders.filter((folder) => folder.parentId === targetId).length
+  const fileCount = (targetId: string) => files.filter((file) => file.folderId === targetId).length
+
+  const deleteFile = (file: MyBookFile) => {
+    void fileRepository.delete(file.id).then((result) => {
+      if (!result.success) return
+      toast.add(deletedToast({
+        itemName: file.name,
+        onUndo: () => { void fileRepository.restore(file.id) },
+      }))
+    })
+  }
+
+  const deleteFolder = (folder: MyBookFolder) => {
+    void folderRepository.delete(folder.id).then((result) => {
+      if (!result.success) return
+      toast.add(deletedToast({
+        itemName: folder.name,
+        onUndo: () => { void folderRepository.restore(folder.id) },
+      }))
+    })
+  }
 
   return (
     <div className="px-4">
@@ -31,42 +76,69 @@ export function SearchPage() {
       <div>
         <div className="mt-3">
           <SearchInput
-            label="Search files"
-            placeholder="Search..."
+            label="Search files and folders"
+            placeholder="Search files and folders..."
             value={query}
             onChange={setQuery}
           />
         </div>
       </div>
 
-      {visibleFiles.length ? (
+      {results.length ? (
         <div className="-mx-4 mt-4 px-1">
-          {visibleFiles.map((file) => (
-            <FileCard
-              key={file.id}
-              name={file.name}
-              meta={`Updated ${new Date(file.updatedAt).toLocaleDateString([], { month: 'short', day: 'numeric' })}`}
-              type={file.type}
-              folderName={folders.find((folder) => folder.id === file.folderId)?.name ?? 'MyBook'}
-              syncStatus={file.syncStatus}
-              onOpen={() => navigate(`/${file.type}/${file.id}`)}
-              action={
-                <FileActionsMenu
-                  fileName={file.name}
-                  folders={folders}
-                  currentFolderId={file.folderId}
-                  onRename={() => setRenameTarget(file)}
-                  onDuplicate={() => void fileRepository.duplicate(file.id)}
-                  onMove={(folderId) => void fileRepository.update(file.id, { folderId })}
-                  onDelete={() => void fileRepository.delete(file.id)}
+          {results.map((result) => {
+            if (result.kind === 'folder') {
+              const folder = result.item
+              return (
+                <FolderCard
+                  key={`folder:${folder.id}`}
+                  name={folder.name}
+                  fileCount={fileCount(folder.id)}
+                  folderCount={folderCount(folder.id)}
+                  driveStatus={folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
+                  onOpen={() => navigate(`/folders/${folder.id}`)}
+                  action={
+                    <FolderActionsMenu
+                      folderName={folder.name}
+                      folders={folders}
+                      folderId={folder.id}
+                      currentParentId={folder.parentId}
+                      onRename={() => setFolderRenameTarget(folder)}
+                      onMove={(folderId) => void folderRepository.update(folder.id, { parentId: folderId })}
+                      onDelete={() => setFolderDeleteTarget(folder)}
+                    />
+                  }
                 />
-              }
-            />
-          ))}
+              )
+            }
+            const file = result.item
+            return (
+              <FileCard
+                key={`file:${file.id}`}
+                name={file.name}
+                meta={`Updated ${formatUpdatedAt(file.updatedAt)}`}
+                type={file.type}
+                folderName={folders.find((folder) => folder.id === file.folderId)?.name ?? 'MyBook'}
+                syncStatus={file.syncStatus}
+                onOpen={() => navigate(`/${file.type}/${file.id}`)}
+                action={
+                  <FileActionsMenu
+                    fileName={file.name}
+                    folders={folders}
+                    currentFolderId={file.folderId}
+                    onRename={() => setRenameTarget(file)}
+                    onDuplicate={() => void fileRepository.duplicate(file.id)}
+                    onMove={(folderId) => void fileRepository.update(file.id, { folderId })}
+                    onDelete={() => setFileDeleteTarget(file)}
+                  />
+                }
+              />
+            )
+          })}
         </div>
       ) : query.trim() ? (
         <div className="pt-16">
-          <EmptyState title="No files found" description="Try another file name." />
+          <EmptyState title="No files or folders found" description="Try another name." />
         </div>
       ) : null}
 
@@ -78,6 +150,45 @@ export function SearchPage() {
           ? fileRepository.update(renameTarget.id, { name })
           : Promise.resolve({ success: false })}
       />
+      <FolderNameDialog
+        isOpen={Boolean(folderRenameTarget)}
+        title="Rename folder"
+        submitLabel="Save"
+        initialName={folderRenameTarget?.name}
+        onClose={() => setFolderRenameTarget(null)}
+        existingFolderNames={folders
+          .filter((folder) => folder.parentId === folderRenameTarget?.parentId && folder.id !== folderRenameTarget?.id)
+          .map((folder) => folder.name)}
+        onSubmit={(name) => folderRenameTarget ? folderRepository.update(folderRenameTarget.id, { name }) : Promise.resolve({ success: false })}
+      />
+      <DeleteFileDialog
+        isOpen={Boolean(fileDeleteTarget)}
+        fileName={fileDeleteTarget?.name ?? ''}
+        onClose={() => setFileDeleteTarget(null)}
+        onConfirm={() => {
+          if (!fileDeleteTarget) return
+          deleteFile(fileDeleteTarget)
+        }}
+      />
+      <DeleteFolderDialog
+        isOpen={Boolean(folderDeleteTarget)}
+        folderName={folderDeleteTarget?.name ?? ''}
+        hasContents={folderDeleteTarget ? itemCount(folderDeleteTarget.id) > 0 : false}
+        onClose={() => setFolderDeleteTarget(null)}
+        onConfirm={() => {
+          if (!folderDeleteTarget) return
+          deleteFolder(folderDeleteTarget)
+        }}
+      />
     </div>
   )
+}
+
+function compareResultsByUpdatedAt(a: SearchResult, b: SearchResult) {
+  const updated = b.item.updatedAt.localeCompare(a.item.updatedAt)
+  if (updated !== 0) return updated
+  const name = a.item.name.localeCompare(b.item.name, 'en-US', { sensitivity: 'base' })
+  if (name !== 0) return name
+  if (a.kind !== b.kind) return a.kind.localeCompare(b.kind)
+  return a.item.id.localeCompare(b.item.id)
 }

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SettingsPage } from './SettingsPage'
+
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockLogout = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('dexie-react-hooks', () => ({
+  useLiveQuery: () => [],
+}))
+
+vi.mock('../hooks/useDriveBootstrap', () => ({
+  useDriveBootstrap: () => ({ isPreparing: false, statusMessage: null }),
+}))
+
+vi.mock('../services/googleDrive', () => ({
+  getDriveFolderStatus: vi.fn().mockResolvedValue(null),
+  openMyBookFolderInDrive: vi.fn(),
+}))
+
+vi.mock('../database/db', () => ({
+  db: {
+    files: { filter: vi.fn(() => ({ toArray: vi.fn().mockResolvedValue([]) })) },
+    syncQueue: { toArray: vi.fn().mockResolvedValue([]) },
+    open: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock('../database/repositories', () => ({
+  processPendingDriveFolderSync: vi.fn(),
+}))
+
+vi.mock('../stores/useAppStore', () => ({
+  useAppStore: () => ({ theme: 'light', toggleTheme: vi.fn() }),
+}))
+
+vi.mock('../stores/useAuthStore', () => ({
+  useAuthStore: () => ({ email: 'user@example.com', logout: mockLogout, reconnect: vi.fn() }),
+}))
+
+describe('SettingsPage', () => {
+  it('logs out from Preferences and navigates to login without blocked-route state', async () => {
+    render(<MemoryRouter><SettingsPage /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: /log out/i }))
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled())
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true, state: null })
+  })
+})

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -42,6 +42,11 @@ export function SettingsPage() {
     void db.open().then(() => setDatabaseStatus('ready')).catch(() => setDatabaseStatus('failed'))
   }, [])
 
+  const handleLogout = async () => {
+    await logout()
+    navigate('/login', { replace: true, state: null })
+  }
+
   return (
     <div className="mx-auto max-w-3xl space-y-4 px-4">
       <PageHeader
@@ -61,7 +66,7 @@ export function SettingsPage() {
         <p className="mt-1 text-sm leading-6 text-muted-foreground">
           {email ? `Signed in as ${email}.` : 'Your Google session will appear here after sign-in.'}
         </p>
-        <AppButton className="mt-4" variant="secondary" onPress={() => void logout()}>
+        <AppButton className="mt-4" variant="secondary" onPress={() => void handleLogout()}>
           <ArrowRightStartOnRectangleIcon aria-hidden="true" className="size-5" />
           Log out
         </AppButton>

--- a/src/pages/TrashPage.test.tsx
+++ b/src/pages/TrashPage.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TrashPage } from './TrashPage'
+import { fileRepository } from '../database/repositories'
+import type { MyBookFile, MyBookFolder } from '../types/files'
+
+const mockNavigate = vi.hoisted(() => vi.fn())
+const mockLibraryData = vi.hoisted((): { files: MyBookFile[]; folders: MyBookFolder[]; isLoading: boolean } => ({
+  files: [],
+  folders: [],
+  isLoading: false,
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../hooks/useLibraryData', () => ({
+  useLibraryData: () => mockLibraryData,
+}))
+
+vi.mock('../database/repositories', () => ({
+  fileRepository: {
+    permanentlyDelete: vi.fn(),
+    restore: vi.fn(),
+  },
+}))
+
+vi.mock('../components/files/TrashActionsMenu', () => ({
+  TrashActionsMenu: ({ fileName, onDelete }: { fileName: string; onDelete: () => void }) => (
+    <button type="button" onClick={onDelete}>Delete permanently {fileName}</button>
+  ),
+}))
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.open = true
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function close(this: HTMLDialogElement) {
+    this.open = false
+  })
+})
+
+beforeEach(() => {
+  mockNavigate.mockClear()
+  mockLibraryData.files = []
+  mockLibraryData.folders = []
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TrashPage', () => {
+  it('requires confirmation before permanently deleting a file', async () => {
+    mockLibraryData.files = [{
+      id: 'file-1',
+      driveFileId: null,
+      name: 'Old notes',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: true,
+    }]
+
+    render(<MemoryRouter><TrashPage /></MemoryRouter>)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete permanently Old notes' }))
+
+    expect(fileRepository.permanentlyDelete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Delete "Old notes" permanently?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete permanently' }))
+
+    await waitFor(() => expect(fileRepository.permanentlyDelete).toHaveBeenCalledWith('file-1'))
+  })
+})

--- a/src/pages/TrashPage.tsx
+++ b/src/pages/TrashPage.tsx
@@ -1,15 +1,62 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { EmptyState } from '../components/common/EmptyState'
 import { PageHeader } from '../components/common/PageHeader'
+import { DeleteFileDialog } from '../components/files/DeleteFileDialog'
 import { FileCard } from '../components/files/FileCard'
 import { TrashActionsMenu } from '../components/files/TrashActionsMenu'
 import { fileRepository } from '../database/repositories'
 import { useLibraryData } from '../hooks/useLibraryData'
+import type { MyBookFile } from '../types/files'
 
 export function TrashPage() {
   const navigate = useNavigate()
   const { files, folders } = useLibraryData(true)
+  const [permanentDeleteTarget, setPermanentDeleteTarget] = useState<MyBookFile | null>(null)
   const trashedFiles = files.filter((file) => file.isDeleted)
-  return <div className="px-4"><PageHeader title="Trash" description="Restore files or permanently remove them." />{trashedFiles.length ? <div className="-mx-4 mt-4 px-1">{trashedFiles.map((file) => <FileCard key={file.id} name={file.name} meta={`Deleted ${new Date(file.updatedAt).toLocaleDateString()}`} type={file.type} folderName={folders.find((folder) => folder.id === file.folderId)?.name ?? 'MyBook'} syncStatus={file.syncStatus} action={<TrashActionsMenu fileName={file.name} onRestore={() => void fileRepository.restore(file.id)} onDelete={() => void fileRepository.permanentlyDelete(file.id)} />} />)}</div> : <div className="pt-16"><EmptyState title="Trash is empty" description="Files you delete will appear here." action={<button type="button" onClick={() => navigate('/search')} className="min-h-11 rounded-lg px-3 text-primary">Browse files</button>} /></div>}</div>
+  return (
+    <div className="px-4">
+      <PageHeader title="Trash" description="Restore files or permanently remove them." />
+      {trashedFiles.length ? (
+        <div className="-mx-4 mt-4 px-1">
+          {trashedFiles.map((file) => (
+            <FileCard
+              key={file.id}
+              name={file.name}
+              meta={`Deleted ${new Date(file.updatedAt).toLocaleDateString()}`}
+              type={file.type}
+              folderName={folders.find((folder) => folder.id === file.folderId)?.name ?? 'MyBook'}
+              syncStatus={file.syncStatus}
+              action={(
+                <TrashActionsMenu
+                  fileName={file.name}
+                  onRestore={() => void fileRepository.restore(file.id)}
+                  onDelete={() => setPermanentDeleteTarget(file)}
+                />
+              )}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="pt-16">
+          <EmptyState
+            title="Trash is empty"
+            description="Files you delete will appear here."
+            action={<button type="button" onClick={() => navigate('/search')} className="min-h-11 rounded-lg px-3 text-primary">Browse files</button>}
+          />
+        </div>
+      )}
+      <DeleteFileDialog
+        isOpen={Boolean(permanentDeleteTarget)}
+        fileName={permanentDeleteTarget?.name ?? ''}
+        mode="permanent"
+        onClose={() => setPermanentDeleteTarget(null)}
+        onConfirm={() => {
+          if (!permanentDeleteTarget) return
+          void fileRepository.permanentlyDelete(permanentDeleteTarget.id)
+        }}
+      />
+    </div>
+  )
 }

--- a/src/services/googleDrive.test.ts
+++ b/src/services/googleDrive.test.ts
@@ -3,10 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { db } from '../database/db'
 import { useAuthStore } from '../stores/useAuthStore'
 import {
+  backupDocumentToDrive,
   createVisibleFolder,
   ensureMyBookDriveFolder,
   importDriveFilesToLocal,
   listVisibleFoldersByName,
+  updateDriveFolder,
   updateDriveFile,
 } from './googleDrive'
 
@@ -28,6 +30,7 @@ vi.mock('../database/db', () => ({
       toArray: vi.fn(),
       add: vi.fn(),
       update: vi.fn(),
+      get: vi.fn(),
     },
     settings: {
       get: vi.fn(),
@@ -52,6 +55,7 @@ describe('googleDrive helpers', () => {
     vi.clearAllMocks()
     mockedGetState.mockReturnValue({ getAccessToken: () => Promise.resolve('token') } as never)
     mockedFiles.get.mockResolvedValue(undefined)
+    mockedFolders.get.mockResolvedValue(undefined)
     vi.stubGlobal('navigator', { onLine: true })
   })
 
@@ -154,6 +158,38 @@ describe('googleDrive helpers', () => {
     }))
   })
 
+  it('preserves updatedAt when Drive import only confirms an unchanged existing file', async () => {
+    mockedSettings.get.mockResolvedValue({ key: 'google-drive.mybook-folder-id', value: null, updatedAt: '2026-07-24T00:00:00.000Z' })
+    mockedFolders.toArray.mockResolvedValue([])
+    mockedFiles.toArray.mockResolvedValue([{
+      id: 'local-note',
+      driveFileId: 'doc-1',
+      name: 'Drive Note',
+      type: 'document',
+      folderId: null,
+      content: '{"type":"doc","content":[{"type":"paragraph"}]}',
+      mimeType: 'text/markdown',
+      createdAt: '2026-08-20T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: '2026-08-22T09:00:00.000Z',
+      syncStatus: 'backed-up',
+      isDeleted: false,
+    }])
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [{ id: 'root-folder', name: 'MyBook', mimeType: 'application/vnd.google-apps.folder' }] }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [{ id: 'doc-1', name: 'Drive Note.mybook.md', mimeType: 'text/markdown', modifiedTime: '2026-08-22T09:00:00.000Z' }] }) })
+      .mockResolvedValueOnce({ ok: true, text: vi.fn().mockResolvedValue('{"type":"doc","content":[{"type":"paragraph"}]}') })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ files: [] }) }))
+
+    await importDriveFilesToLocal()
+
+    expect(mockedFiles.update).toHaveBeenCalledWith('local-note', expect.objectContaining({
+      updatedAt: '2026-08-22T00:00:00.000Z',
+      lastSyncedAt: '2026-08-22T09:00:00.000Z',
+      syncStatus: 'backed-up',
+    }))
+  })
+
   it('moves a Drive file with addParents and removeParents', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ parents: ['old-parent'] }) })
@@ -165,5 +201,59 @@ describe('googleDrive helpers', () => {
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain('addParents=new-parent')
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain('removeParents=old-parent')
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: 'PATCH', body: '{}' })
+  })
+
+  it('moves existing Drive-backed documents to their local folder during backup', async () => {
+    mockedSettings.get.mockResolvedValue({ key: 'google-drive.mybook-folder-id', value: 'mybook-root', updatedAt: '2026-07-24T00:00:00.000Z' })
+    mockedFolders.get.mockResolvedValue({
+      id: 'folder-1',
+      driveFolderId: 'drive-folder',
+      name: 'Projects',
+      parentId: null,
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      isDeleted: false,
+    })
+    mockedFiles.get.mockResolvedValue({
+      id: 'file-1',
+      driveFileId: 'drive-doc',
+      name: 'Notes',
+      type: 'document',
+      folderId: 'folder-1',
+      content: '{"type":"doc","content":[{"type":"paragraph"}]}',
+      mimeType: 'application/x-mybook-document',
+      createdAt: '2026-08-29T00:00:00.000Z',
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      lastSyncedAt: '2026-08-29T00:00:00.000Z',
+      syncStatus: 'backed-up',
+      isDeleted: false,
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ parents: ['mybook-root'] }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ id: 'drive-doc', name: 'Notes.mybook.md', modifiedTime: '2026-08-29T10:00:00.000Z' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await backupDocumentToDrive({
+      fileId: 'file-1',
+      title: 'Notes',
+      content: '{"type":"doc","content":[{"type":"paragraph"}]}',
+      folderId: 'folder-1',
+    })
+
+    expect(result.success).toBe(true)
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('addParents=drive-folder')
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('removeParents=mybook-root')
+  })
+
+  it('moves Drive folders to the requested parent and removes old parents', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ parents: ['old-parent'] }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ id: 'folder-1', name: 'Projects', mimeType: 'application/vnd.google-apps.folder' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateDriveFolder('folder-1', { parentId: 'mybook-root' })
+
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('addParents=mybook-root')
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('removeParents=old-parent')
   })
 })

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -91,6 +91,25 @@ async function listChildFiles(parentId: string): Promise<DriveFile[]> {
   return data.files ?? []
 }
 
+async function parentMoveParams(fileId: string, targetParentId: string, accessToken: string) {
+  const params = new URLSearchParams()
+  const currentResponse = await fetch(`${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?fields=parents`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!currentResponse.ok) {
+    const body = await currentResponse.json().catch(() => null) as { error?: { message?: string } } | null
+    throw new Error(body?.error?.message ?? 'Could not read the Google Drive file location.')
+  }
+  const current = await currentResponse.json().catch(() => null) as { parents?: string[] } | null
+  const currentParents = current?.parents ?? []
+  const parentsToRemove = currentParents.filter((parentId) => parentId !== targetParentId)
+
+  if (!currentParents.includes(targetParentId)) params.set('addParents', targetParentId)
+  if (parentsToRemove.length) params.set('removeParents', parentsToRemove.join(','))
+
+  return params
+}
+
 async function getDriveFileContent(fileId: string) {
   const accessToken = await useAuthStore.getState().getAccessToken()
   if (!accessToken) throw new Error('Your Google session expired. Please sign in again.')
@@ -169,12 +188,8 @@ export async function updateDriveFolder(folderId: string, changes: { name?: stri
   if (changes.name !== undefined) metadata.name = changes.name
   const params = new URLSearchParams({ fields: 'id,name,mimeType,webViewLink' })
   if (changes.parentId) {
-    const currentResponse = await fetch(`${DRIVE_API_BASE}/files/${folderId}?fields=parents`, { headers: { Authorization: `Bearer ${accessToken}` } })
-    const current = await currentResponse.json().catch(() => null) as { parents?: string[] } | null
-    if (!current?.parents?.includes(changes.parentId)) {
-      params.set('addParents', changes.parentId)
-      if (current?.parents?.length) params.set('removeParents', current.parents.join(','))
-    }
+    const moveParams = await parentMoveParams(folderId, changes.parentId, accessToken)
+    moveParams.forEach((value, key) => params.set(key, value))
   }
   const response = await fetch(`${DRIVE_API_BASE}/files/${folderId}?${params.toString()}`, {
     method: 'PATCH',
@@ -249,12 +264,9 @@ export async function updateDriveFile(fileId: string, changes: { name?: string; 
 
   const parentParams = new URLSearchParams()
   if (changes.parentId !== undefined) {
-    const currentResult = await driveFetch(`/files/${encodeURIComponent(fileId)}?fields=parents`)
-    if (!currentResult.success) throw new Error(currentResult.error)
-    const current = await currentResult.response.json() as { parents?: string[] }
-    if (changes.parentId && !current.parents?.includes(changes.parentId)) {
-      parentParams.set('addParents', changes.parentId)
-      if (current.parents?.length) parentParams.set('removeParents', current.parents.join(','))
+    if (changes.parentId) {
+      const moveParams = await parentMoveParams(fileId, changes.parentId, accessToken)
+      moveParams.forEach((value, key) => parentParams.set(key, value))
     }
   }
 
@@ -365,8 +377,13 @@ async function uploadMarkdownFile(title: string, content: string, parentId: stri
     mimeType: MYBOOK_MARKDOWN_MIME,
   }
   const method = fileId ? 'PATCH' : 'POST'
+  const query = new URLSearchParams({ uploadType: 'multipart', fields: 'id,name,webViewLink,modifiedTime' })
+  if (fileId) {
+    const moveParams = await parentMoveParams(fileId, parentId, accessToken)
+    moveParams.forEach((value, key) => query.set(key, value))
+  }
   const endpoint = fileId
-    ? `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=multipart&fields=id,name,webViewLink,modifiedTime`
+    ? `https://www.googleapis.com/upload/drive/v3/files/${fileId}?${query.toString()}`
     : 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink,modifiedTime'
   const response = await fetch(endpoint, {
     method,
@@ -439,8 +456,13 @@ async function uploadXlsxBlob(name: string, blob: Blob, parentId: string, fileId
   }
   const boundary = 'mybook-xlsx-boundary'
   const method = fileId ? 'PATCH' : 'POST'
+  const query = new URLSearchParams({ uploadType: 'multipart', fields: 'id,name,webViewLink,modifiedTime' })
+  if (fileId) {
+    const moveParams = await parentMoveParams(fileId, parentId, accessToken)
+    moveParams.forEach((value, key) => query.set(key, value))
+  }
   const endpoint = fileId
-    ? `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=multipart&fields=id,name,webViewLink,modifiedTime`
+    ? `https://www.googleapis.com/upload/drive/v3/files/${fileId}?${query.toString()}`
     : 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink,modifiedTime'
   const response = await fetch(endpoint, {
     method,
@@ -825,17 +847,27 @@ export async function importDriveFilesToLocal() {
         content = ''
       }
       if (existing) {
+        const name = localFileName(driveFile.name, fileType)
+        const type = existing.type ?? fileType
+        const mimeType = driveFile.mimeType || existing.mimeType
         const driveIsNewer = !existing.lastSyncedAt || new Date(driveModifiedTime).getTime() > new Date(existing.lastSyncedAt).getTime()
         const nextContent = driveIsNewer && content && content !== existing.content ? content : existing.content
         if (nextContent !== existing.content) await saveVersionBeforeDriveUpdate(existing.id, driveModifiedTime)
+        const userVisibleChanged =
+          name !== existing.name ||
+          parentLocalId !== existing.folderId ||
+          type !== existing.type ||
+          mimeType !== existing.mimeType ||
+          nextContent !== existing.content ||
+          existing.isDeleted
         await db.files.update(existing.id, {
-          name: localFileName(driveFile.name, fileType),
+          name,
           folderId: parentLocalId,
           driveFileId: driveFile.id,
-          type: existing.type ?? fileType,
-          mimeType: driveFile.mimeType || existing.mimeType,
+          type,
+          mimeType,
           content: nextContent,
-          updatedAt: now,
+          updatedAt: userVisibleChanged ? now : existing.updatedAt,
           lastSyncedAt: driveModifiedTime,
           syncStatus: 'backed-up',
           syncError: null,

--- a/src/utils/dateFormat.test.ts
+++ b/src/utils/dateFormat.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatUpdatedAt } from './dateFormat'
+
+describe('formatUpdatedAt', () => {
+  it('uses consistent relative and absolute app formatting', () => {
+    const now = new Date('2026-08-29T12:00:00.000Z')
+
+    expect(formatUpdatedAt('2026-08-29T11:59:45.000Z', now)).toBe('just now')
+    expect(formatUpdatedAt('2026-08-29T11:59:00.000Z', now)).toBe('1 min ago')
+    expect(formatUpdatedAt('2026-08-29T11:47:00.000Z', now)).toBe('13 mins ago')
+    expect(formatUpdatedAt('2026-08-29T11:00:00.000Z', now)).toBe('1 hr ago')
+    expect(formatUpdatedAt('2026-08-29T08:00:00.000Z', now)).toBe('4 hrs ago')
+    expect(formatUpdatedAt('2026-08-29T05:05:00.000Z', now)).toBe('today, 5:05 AM')
+    expect(formatUpdatedAt('2026-08-28T16:17:00.000Z', now)).toBe('yesterday, 4:17 PM')
+    expect(formatUpdatedAt('2026-08-22T09:05:00.000Z', now)).toBe('Aug 22, 2026, 9:05 AM')
+  })
+})

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,45 @@
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+const shortTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZone: 'UTC',
+})
+
+export function formatUpdatedAt(value: string, now = new Date()) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  const elapsedMs = now.getTime() - date.getTime()
+  const elapsedMinutes = Math.floor(elapsedMs / 60_000)
+  const elapsedHours = Math.floor(elapsedMs / 3_600_000)
+
+  if (elapsedMs >= 0 && elapsedMinutes < 1) return 'just now'
+  if (elapsedMs >= 0 && elapsedMinutes < 60) return `${elapsedMinutes} ${elapsedMinutes === 1 ? 'min' : 'mins'} ago`
+  if (elapsedMs >= 0 && elapsedHours < 6) return `${elapsedHours} ${elapsedHours === 1 ? 'hr' : 'hrs'} ago`
+  if (isSameUtcDate(date, now)) {
+    return `today, ${shortTimeFormatter.format(date)}`
+  }
+  if (isYesterdayUtc(date, now)) {
+    return `yesterday, ${shortTimeFormatter.format(date)}`
+  }
+
+  return `${shortDateFormatter.format(date)}, ${shortTimeFormatter.format(date)}`
+}
+
+function isSameUtcDate(a: Date, b: Date) {
+  return a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
+}
+
+function isYesterdayUtc(date: Date, now: Date) {
+  const yesterday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1))
+  return date.getUTCFullYear() === yesterday.getUTCFullYear() &&
+    date.getUTCMonth() === yesterday.getUTCMonth() &&
+    date.getUTCDate() === yesterday.getUTCDate()
+}

--- a/src/utils/deleteToast.ts
+++ b/src/utils/deleteToast.ts
@@ -1,0 +1,19 @@
+import type { ToastManagerAddOptions } from '@base-ui/react/toast'
+
+interface DeleteToastOptions {
+  itemName: string
+  onUndo: () => void
+}
+
+export function deletedToast({ itemName, onUndo }: DeleteToastOptions): ToastManagerAddOptions<object> {
+  return {
+    title: `"${itemName}" deleted`,
+    type: 'success',
+    priority: 'low',
+    actionProps: {
+      children: 'Undo',
+      'aria-label': `Undo deleting ${itemName}`,
+      onClick: onUndo,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Fix Library/Home/Search folder and file counts, empty states, breadcrumbs, and search visibility.
- Improve folder creation flow with duplicate validation, direct navigation, and success toast.
- Add delete confirmations across file/folder listings, open editors, Trash, and document block deletion.
- Add delete toast with Undo for files and folders.
- Preserve updated timestamps during no-op Drive imports and stabilize ordering.
- Add unique default file names and correct duplicate behavior from listings vs open editors.
- Fix logout redirect state so login does not show a stale auth-required message.

## Checks
- npm run lint
- npm run typecheck
- npm test -- --run --maxWorkers=1
- npm run build

## Notes
- Lint passes with existing Fast Refresh warnings.
- Build passes with existing Vite chunk/import warnings.