### PR TITLE
fix: stabilize mobile scrolling and sync timestamps

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,11 +14,15 @@ export function App() {
     void initializeSession()
   }, [initializeSession])
 
-  return <>
-    <TooltipProvider>
+  return (
+    <div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-background text-foreground">
+      <TooltipProvider>
       <PwaStatus />
-      <RouterProvider router={router} />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <RouterProvider router={router} />
+      </div>
       <Toaster />
-    </TooltipProvider>
-  </>
+      </TooltipProvider>
+    </div>
+  )
 }

--- a/src/components/common/PwaStatus.tsx
+++ b/src/components/common/PwaStatus.tsx
@@ -100,8 +100,8 @@ export function PwaStatus() {
   }, [checkForUpdates, isIos, registration])
 
   return <>
-    {!online ? <div role="status" className="border-b border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-center text-sm text-yellow-800"><SignalIcon className="mr-1 inline size-4" />Offline mode: saved local files remain available. Drive sync will resume when you reconnect.</div> : null}
-    {needRefresh ? <div role="status" className="border-b border-accent/30 bg-primary/10 px-4 py-2 text-center text-sm"><ArrowPathIcon aria-hidden="true" className="mr-1 inline size-4" />Update available. <button type="button" className="min-h-11 rounded-lg px-2 font-semibold underline" onClick={() => void updateServiceWorker(true)}>Update MyBook</button></div> : null}
+    {!online ? <div role="status" className="shrink-0 border-b border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-center text-sm text-yellow-800"><SignalIcon className="mr-1 inline size-4" />Offline mode: saved local files remain available. Drive sync will resume when you reconnect.</div> : null}
+    {needRefresh ? <div role="status" className="shrink-0 border-b border-accent/30 bg-primary/10 px-4 py-2 text-center text-sm"><ArrowPathIcon aria-hidden="true" className="mr-1 inline size-4" />Update available. <button type="button" className="min-h-11 rounded-lg px-2 font-semibold underline" onClick={() => void updateServiceWorker(true)}>Update MyBook</button></div> : null}
 
     <Dialog
       open={showInstallHelp}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -36,8 +36,8 @@ export function AppLayout() {
 
   if (isEditor) {
     return (
-      <div className="flex h-dvh min-h-[480px] flex-col overflow-hidden bg-background text-foreground">
-        <main className="min-w-0 flex-1 overflow-x-auto overflow-y-auto overscroll-contain bg-background p-0">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground">
+        <main className="min-h-0 min-w-0 flex-1 overflow-x-auto overflow-y-auto overscroll-contain bg-background p-0">
           <Outlet />
         </main>
       </div>
@@ -45,7 +45,7 @@ export function AppLayout() {
   }
 
   return (
-    <SidebarProvider className="h-dvh min-h-[480px] overflow-hidden bg-background text-foreground">
+    <SidebarProvider className="h-full min-h-0 overflow-hidden bg-background text-foreground">
       <Sidebar side="left" collapsible="icon">
         <SidebarHeader>
           <SidebarMenu>
@@ -100,7 +100,7 @@ export function AppLayout() {
         <SidebarRail />
       </Sidebar>
 
-      <SidebarInset className="min-w-0 overflow-hidden">
+      <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
         <header className="sticky top-0 z-30 hidden shrink-0 border-b bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur md:block">
           <div className="flex h-16 w-full items-center gap-3 px-4 sm:px-6 lg:px-8">
             <div className="ml-auto flex items-center gap-2">
@@ -122,7 +122,7 @@ export function AppLayout() {
           </div>
         </header>
 
-        <main className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain bg-background px-0 pb-[calc(7rem+env(safe-area-inset-bottom))] md:px-8 md:pb-8 md:pt-6">
+        <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain bg-background px-0 pb-4 md:px-8 md:pb-8 md:pt-6">
           <div className="mx-auto w-full max-w-6xl">
             <Outlet />
           </div>

--- a/src/components/layout/MobileBottomNavigation.tsx
+++ b/src/components/layout/MobileBottomNavigation.tsx
@@ -4,8 +4,8 @@ import { navigationItems } from '../../utils/navigation'
 
 export function MobileBottomNavigation() {
   return (
-    <nav aria-label="Primary navigation" className="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] pt-4 md:hidden">
-      <div className="pointer-events-auto mx-auto grid max-w-[22rem] grid-cols-4 gap-0.5 rounded-full bg-muted p-1">
+    <nav aria-label="Primary navigation" className="shrink-0 bg-background px-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] pt-4 md:hidden">
+      <div className="mx-auto grid max-w-[22rem] grid-cols-4 gap-0.5 rounded-full bg-muted p-1">
         {navigationItems.map((item) => (
           <NavLink
             key={item.path}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -139,7 +139,7 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          "group/sidebar-wrapper flex h-full min-h-0 w-full has-data-[variant=inset]:bg-sidebar",
           className
         )}
         {...props}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -73,7 +73,7 @@ export function LoginPage() {
   }
 
   return (
-    <main className="flex min-h-dvh items-center justify-center bg-background px-4 pb-[calc(2.5rem+env(safe-area-inset-bottom))] pt-[calc(2.5rem+env(safe-area-inset-top))] text-foreground sm:px-6">
+    <main className="flex h-full min-h-0 items-center justify-center overflow-y-auto overscroll-contain bg-background px-4 pb-[calc(2.5rem+env(safe-area-inset-bottom))] pt-[calc(2.5rem+env(safe-area-inset-top))] text-foreground sm:px-6">
       <section className="w-full max-w-sm" aria-labelledby="login-title">
         <div className="mb-6 flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
           <BookOpenIcon aria-hidden="true" className="size-7" />

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -867,7 +867,7 @@ export async function importDriveFilesToLocal() {
           type,
           mimeType,
           content: nextContent,
-          updatedAt: userVisibleChanged ? now : existing.updatedAt,
+          updatedAt: userVisibleChanged ? driveModifiedTime : existing.updatedAt,
           lastSyncedAt: driveModifiedTime,
           syncStatus: 'backed-up',
           syncError: null,
@@ -883,7 +883,7 @@ export async function importDriveFilesToLocal() {
           content,
           mimeType: driveFile.mimeType,
           createdAt: now,
-          updatedAt: now,
+          updatedAt: driveModifiedTime,
           lastSyncedAt: driveModifiedTime,
           syncStatus: 'backed-up',
           isDeleted: false,
@@ -940,7 +940,7 @@ export async function refreshDriveFileToLocal(fileId: string): Promise<{ updated
       lastSyncedAt: driveModifiedTime,
       syncStatus: 'backed-up',
       syncError: null,
-      updatedAt: new Date().toISOString(),
+      updatedAt: driveModifiedTime,
     })
     return { updated: true, modifiedTime: driveModifiedTime }
   } catch (error) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -61,16 +61,19 @@
 
 @layer base {
   html {
+    height: 100%;
     min-width: 320px;
+    overflow: hidden;
     background: var(--background);
     touch-action: pan-x pan-y;
     @apply font-sans;
   }
 
   body {
-    min-height: 100vh;
+    width: 100%;
+    height: 100%;
     margin: 0;
-    overflow-x: hidden;
+    overflow: hidden;
     color: var(--foreground);
     background: var(--background);
     font-family: var(--font-sans);
@@ -79,8 +82,16 @@
     @apply bg-background text-foreground;
   }
 
+  #root {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: var(--background);
+  }
+
   main {
     scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
   }
 
   main::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- Fixes Drive-import timestamp behavior so passive sync/import does not make files appear “updated just now”
- Uses provider modified time for imported/refreshed Drive files instead of local sync time
- Stabilizes mobile/PWA scrolling by locking html/body/root and making the app shell own viewport height
- Moves mobile bottom navigation into normal layout flow instead of fixed positioning
- Keeps PWA banners and login screen inside the height-managed app frame

## Testing

- npm run lint
- npm run typecheck
- npm test -- --run
- npm run build

## Notes

Lint passes with existing Fast Refresh warnings only. Build passes with existing chunk-size warnings.