### PR TITLE
Add local workspace storage flow

### DIFF
--- a/src/app/AuthGuards.test.tsx
+++ b/src/app/AuthGuards.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { RedirectAuthenticated, RequireAuth } from './AuthGuards'
 import { LegacyGoogleAuthStartRedirect } from './LegacyGoogleAuthStartRedirect'
 import { useAuthStore } from '../stores/useAuthStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 
 function LoginState() {
   const location = useLocation()
@@ -15,7 +16,12 @@ function LoginState() {
 }
 
 describe('route protection', () => {
-  beforeEach(() => useAuthStore.setState({ isAuthenticated: false, isLoading: false, error: null }))
+  afterEach(() => cleanup())
+
+  beforeEach(() => {
+    useAuthStore.setState({ isAuthenticated: false, isLoading: false, error: null })
+    useWorkspaceStore.setState({ mode: null })
+  })
 
   it('redirects unauthenticated users to login', () => {
     render(<MemoryRouter initialEntries={['/home']}><Routes><Route element={<RequireAuth />}><Route path="/home" element={<p>Home</p>} /></Route><Route path="/login" element={<p>Login</p>} /></Routes></MemoryRouter>)
@@ -24,6 +30,18 @@ describe('route protection', () => {
 
   it('redirects authenticated users away from login', () => {
     useAuthStore.setState({ isAuthenticated: true })
+    render(<MemoryRouter initialEntries={['/login']}><Routes><Route element={<RedirectAuthenticated />}><Route path="/login" element={<p>Login</p>} /></Route><Route path="/home" element={<p>Home</p>} /></Routes></MemoryRouter>)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+  })
+
+  it('allows local workspace users without a Google session', () => {
+    useWorkspaceStore.setState({ mode: 'local' })
+    render(<MemoryRouter initialEntries={['/home']}><Routes><Route element={<RequireAuth />}><Route path="/home" element={<p>Home</p>} /></Route><Route path="/login" element={<p>Login</p>} /></Routes></MemoryRouter>)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+  })
+
+  it('redirects local workspace users away from login', () => {
+    useWorkspaceStore.setState({ mode: 'local' })
     render(<MemoryRouter initialEntries={['/login']}><Routes><Route element={<RedirectAuthenticated />}><Route path="/login" element={<p>Login</p>} /></Route><Route path="/home" element={<p>Home</p>} /></Routes></MemoryRouter>)
     expect(screen.getByText('Home')).toBeInTheDocument()
   })

--- a/src/app/AuthGuards.tsx
+++ b/src/app/AuthGuards.tsx
@@ -1,17 +1,19 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
 import { useAuthStore } from '../stores/useAuthStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 
 export function RequireAuth() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const isLoading = useAuthStore((state) => state.isLoading)
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
   const location = useLocation()
 
   if (isLoading) {
     return <div role="status" className="p-4 text-base text-muted-foreground">Checking session...</div>
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated && workspaceMode !== 'local') {
     return <Navigate to="/login" replace state={{ from: location.pathname }} />
   }
 
@@ -21,10 +23,11 @@ export function RequireAuth() {
 export function RedirectAuthenticated() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const isLoading = useAuthStore((state) => state.isLoading)
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
 
   if (isLoading) {
     return <div role="status" className="p-4 text-base text-muted-foreground">Checking session...</div>
   }
 
-  return isAuthenticated ? <Navigate to="/home" replace /> : <Outlet />
+  return isAuthenticated || workspaceMode === 'local' ? <Navigate to="/home" replace /> : <Outlet />
 }

--- a/src/components/common/SyncStatusBadge.tsx
+++ b/src/components/common/SyncStatusBadge.tsx
@@ -12,6 +12,7 @@ interface SyncStatusBadgeProps {
 }
 
 const statusConfig = {
+  local: { label: 'Stored locally', className: 'bg-muted text-muted-foreground', icon: CheckCircleIcon },
   pending: { label: 'Syncing', className: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-300', icon: ArrowPathIcon },
   'backing-up': { label: 'Syncing', className: 'bg-primary/10 text-primary', icon: ArrowPathIcon },
   'backed-up': { label: 'Synced', className: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300', icon: CheckCircleIcon },

--- a/src/components/document-editor/EditorStatus.test.tsx
+++ b/src/components/document-editor/EditorStatus.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { EditorStatus } from './EditorStatus'
+
+describe('EditorStatus', () => {
+  afterEach(() => cleanup())
+
+  it('shows pending Drive sync as saved locally instead of endless saving', () => {
+    render(<EditorStatus status="pending" />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Saved')
+    expect(screen.queryByText('Saving...')).not.toBeInTheDocument()
+  })
+
+  it('shows retry for failed sync', () => {
+    const retry = vi.fn()
+    render(<EditorStatus status="failed" onRetry={retry} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent("Couldn't sync")
+    screen.getByRole('button', { name: 'Retry' }).click()
+    expect(retry).toHaveBeenCalled()
+  })
+})

--- a/src/components/document-editor/EditorStatus.tsx
+++ b/src/components/document-editor/EditorStatus.tsx
@@ -1,19 +1,30 @@
-import { ArrowPathIcon, CheckCircleIcon, CloudArrowUpIcon, ExclamationCircleIcon, PencilIcon, SignalSlashIcon } from '@heroicons/react/20/solid'
-
 import type { EditorSaveStatus } from '../../types/files'
 
 const config = {
-  editing: ['Editing', PencilIcon],
-  'saving-locally': ['Saving', ArrowPathIcon],
-  'saved-locally': ['Saved', CheckCircleIcon],
-  pending: ['Syncing', CloudArrowUpIcon],
-  'backing-up': ['Syncing', ArrowPathIcon],
-  'backed-up': ['Synced', CheckCircleIcon],
-  failed: ['Sync paused', ExclamationCircleIcon],
-  offline: ['Offline', SignalSlashIcon],
+  editing: 'Saving...',
+  'saving-locally': 'Saving...',
+  'saved-locally': 'Saved',
+  local: 'Saved',
+  pending: 'Saved',
+  'backing-up': 'Saving...',
+  'backed-up': 'Saved',
+  failed: "Couldn't sync",
+  offline: 'Offline - changes saved locally',
 } as const
 
-export function EditorStatus({ status }: { status: EditorSaveStatus }) {
-  const [label, Icon] = config[status]
-  return <span role="status" aria-live="polite" aria-label={`Editor status: ${label}`} className="inline-flex min-h-8 items-center gap-1.5 text-sm text-muted-foreground"><Icon aria-hidden="true" className={`size-4 ${status === 'saving-locally' || status === 'backing-up' ? 'animate-spin' : ''}`} />{label}</span>
+export function EditorStatus({ status, onRetry }: { status: EditorSaveStatus; onRetry?: () => void }) {
+  const label = config[status]
+  if (status === 'failed' && onRetry) {
+    return (
+      <span role="status" aria-live="polite" aria-label={`Editor status: ${label}`} className="inline-flex min-h-7 items-center gap-1.5 text-sm text-muted-foreground">
+        <span>{label}</span>
+        <span aria-hidden="true">·</span>
+        <button type="button" onClick={onRetry} className="font-medium text-foreground underline-offset-4 hover:underline">
+          Retry
+        </button>
+      </span>
+    )
+  }
+
+  return <span role="status" aria-live="polite" aria-label={`Editor status: ${label}`} className="inline-flex min-h-7 items-center text-sm text-muted-foreground">{label}</span>
 }

--- a/src/components/document-editor/TiptapDocumentEditor.tsx
+++ b/src/components/document-editor/TiptapDocumentEditor.tsx
@@ -111,7 +111,6 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
   const [loadedId, setLoadedId] = useState<string | null>(null)
   const [docxBlob, setDocxBlob] = useState<Blob | null>(null)
   const [docxMessage, setDocxMessage] = useState('')
-  const [cloudMessage, setCloudMessage] = useState<string | null>(null)
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null)
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
   const [isFullWidth, setIsFullWidth] = useState(false)
@@ -246,17 +245,12 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     cloudTimerRef.current = window.setTimeout(() => {
       if (cloudFlightRef.current || !file || file.isDeleted || file.type !== 'document') return
       cloudFlightRef.current = true
-      setCloudMessage('Syncing…')
       void (async () => {
         try {
           const [savedContent] = await Promise.all([save(), saveTitle()])
-          if (!savedContent) {
-            setCloudMessage('Save failed. Sync paused.')
-            return
-          }
+          if (!savedContent) return
           const result = await backupDocumentToDrive({ fileId: file.id, title, content, folderId: file.folderId })
-          if (result.success) setCloudMessage('Synced')
-          else setCloudMessage(result.error)
+          if (!result.success) toast.add({ title: "Couldn't sync", description: result.error, type: 'error', priority: 'low' })
         } finally {
           cloudFlightRef.current = false
         }
@@ -277,14 +271,18 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
     await saveAll()
     const latest = (await fileRepository.get(file.id)).data
     if (!latest) return
-    setCloudMessage('Syncing…')
     const result = await backupDocumentToDrive({ fileId: latest.id, title: latest.name, content: latest.content, folderId: latest.folderId })
-    setCloudMessage(result.success ? 'Synced' : result.error ?? 'Sync failed.')
+    if (!result.success) toast.add({ title: "Couldn't sync", description: result.error ?? 'Sync failed.', type: 'error', priority: 'low' })
   }
   const copyDriveLink = async () => {
     if (!file.driveFileId) return
     const result = await copyDriveFileLink(file.driveFileId)
-    setCloudMessage(result.success ? 'Backup link copied.' : result.error ?? 'Could not copy the backup link.')
+    toast.add({
+      title: result.success ? 'Backup link copied' : 'Could not copy the backup link',
+      description: result.success ? undefined : result.error,
+      type: result.success ? 'success' : 'error',
+      priority: 'low',
+    })
   }
   const close = async () => { await saveAll(); navigate(file.folderId ? `/folders/${file.folderId}` : '/home') }
   const deleteDocument = async () => {
@@ -456,6 +454,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
   const documentPageClass = isFullWidth
     ? 'mybook-document-page mx-auto min-h-[calc(100dvh-13rem)] w-full bg-[var(--app-surface)] px-6 py-10 shadow-none sm:px-8 md:min-h-[calc(100dvh-13rem)] md:px-12 md:py-16 lg:px-16'
     : 'mybook-document-page mybook-document-page--continuous mx-auto min-h-[calc(100dvh-13rem)] w-full bg-transparent px-4 pb-[55vh] pt-6 shadow-none sm:px-6 md:px-16 md:pb-[55vh] md:pt-14'
+  const editorStatus = file.syncStatus === 'failed' && status !== 'editing' && status !== 'saving-locally' && status !== 'saved-locally' ? 'failed' : status
 
   return (
     <section className={`mybook-document-editor min-h-dvh w-full pb-[calc(5.25rem+env(safe-area-inset-bottom))] md:pb-0 ${documentSurfaceClass}`}>
@@ -465,9 +464,7 @@ export function TiptapDocumentEditor({ fileId }: { fileId: string }) {
           <div className="min-w-0 flex-1">
             <label htmlFor="document-title" className="sr-only">Document title</label>
             <input id="document-title" value={title} onChange={(event) => setTitle(event.target.value)} onBlur={() => void saveTitle()} className="h-8 w-full truncate rounded-[6px] bg-transparent text-base font-semibold outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background" />
-            <EditorStatus status={status} />
-            {cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}
-            {file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}
+            <EditorStatus status={editorStatus} onRetry={() => void backupNow()} />
             <div className="mt-1">
               <FolderBreadcrumb currentFolderId={file.folderId} folders={folders} currentPageLabel={title} onNavigate={navigate} />
             </div>

--- a/src/components/files/FolderManagerView.tsx
+++ b/src/components/files/FolderManagerView.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { fileRepository, folderRepository } from '../../database/repositories'
 import { useLibraryData } from '../../hooks/useLibraryData'
+import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import type { MyBookFile, MyBookFolder } from '../../types/files'
 import { formatUpdatedAt } from '../../utils/dateFormat'
 import { deletedToast } from '../../utils/deleteToast'
@@ -29,6 +30,7 @@ interface FolderManagerViewProps {
 export function FolderManagerView({ folderId }: FolderManagerViewProps) {
   const navigate = useNavigate()
   const { files, folders } = useLibraryData()
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
   const [isCreating, setIsCreating] = useState(false)
   const [renameTarget, setRenameTarget] = useState<MyBookFolder | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<MyBookFolder | null>(null)
@@ -148,7 +150,7 @@ export function FolderManagerView({ folderId }: FolderManagerViewProps) {
             name={folder.name}
             fileCount={fileCount(folder.id)}
             folderCount={folderCount(folder.id)}
-            driveStatus={folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
+            driveStatus={workspaceMode === 'local' ? 'Stored locally' : folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
             onOpen={() => navigate(`/folders/${folder.id}`)}
             action={
               <FolderActionsMenu

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -8,6 +8,7 @@ import { NavLink, Outlet, useLocation } from 'react-router-dom'
 
 import { useAppStore } from '../../stores/useAppStore'
 import { useAuthStore } from '../../stores/useAuthStore'
+import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import { useDriveBootstrap } from '../../hooks/useDriveBootstrap'
 import { navigationItems } from '../../utils/navigation'
 import { IconButton } from '../common/IconButton'
@@ -30,6 +31,7 @@ import { MobileBottomNavigation } from './MobileBottomNavigation'
 export function AppLayout() {
   const { theme, toggleTheme } = useAppStore()
   const { email, isAuthenticated } = useAuthStore()
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
   useDriveBootstrap()
   const { pathname } = useLocation()
   const isEditor = pathname.startsWith('/document/') || pathname.startsWith('/spreadsheet/')
@@ -104,8 +106,8 @@ export function AppLayout() {
         <header className="sticky top-0 z-30 hidden shrink-0 border-b bg-background/95 pt-[env(safe-area-inset-top)] backdrop-blur md:block">
           <div className="flex h-16 w-full items-center gap-3 px-4 sm:px-6 lg:px-8">
             <div className="ml-auto flex items-center gap-2">
-              <span className={`hidden max-w-[16rem] rounded-full px-3 py-1 text-xs font-medium sm:inline-flex ${isAuthenticated ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300' : 'bg-muted text-muted-foreground'}`}>
-                {isAuthenticated ? `Signed in${email ? ` as ${email}` : ''}` : 'Not signed in'}
+              <span className={`hidden max-w-[16rem] rounded-full px-3 py-1 text-xs font-medium sm:inline-flex ${isAuthenticated || workspaceMode === 'local' ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300' : 'bg-muted text-muted-foreground'}`}>
+                {isAuthenticated ? `Signed in${email ? ` as ${email}` : ''}` : workspaceMode === 'local' ? 'Local workspace' : 'Not signed in'}
               </span>
               <IconButton
                 label={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}

--- a/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
+++ b/src/components/spreadsheet-editor/UniverSpreadsheetEditor.tsx
@@ -43,7 +43,6 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   const [xlsxMessage, setXlsxMessage] = useState<string | null>(null)
   const [xlsxWarnings, setXlsxWarnings] = useState<string[]>([])
   const [isConverting, setIsConverting] = useState(false)
-  const [cloudMessage, setCloudMessage] = useState<string | null>(null)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const cloudTimerRef = useRef<number | null>(null)
   const cloudFlightRef = useRef(false)
@@ -109,16 +108,15 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     cloudTimerRef.current = window.setTimeout(() => {
       if (cloudFlightRef.current || !file || file.isDeleted) return
       cloudFlightRef.current = true
-      setCloudMessage('Syncing…')
       void (async () => {
         try {
           const saved = await save()
-          if (!saved) { setCloudMessage('Save failed. Sync paused.'); return }
+          if (!saved) return
           const latest = await fileRepository.get(file.id)
           const latestFile = latest.data
-          if (!latestFile) { setCloudMessage('Spreadsheet could not be found.'); return }
+          if (!latestFile) return
           const result = await backupSpreadsheetToDrive({ fileId: file.id, title: latestFile.name, content: latestFile.content, folderId: latestFile.folderId })
-          setCloudMessage(result.success ? 'Synced' : result.error)
+          if (!result.success) toast.add({ title: "Couldn't sync", description: result.error, type: 'error', priority: 'low' })
         } finally {
           cloudFlightRef.current = false
         }
@@ -196,20 +194,24 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
   const backupNow = async () => {
     if (!file) return
     const snapshot = workbookRef.current?.save() as UniverWorkbookSnapshot | undefined
-    if (!snapshot) { setCloudMessage('The spreadsheet is not ready yet.'); return }
+    if (!snapshot) { toast.add({ title: 'Spreadsheet is not ready yet', type: 'warning', priority: 'low' }); return }
     setContent(JSON.stringify(snapshot))
     await save()
     const latest = (await fileRepository.get(file.id)).data
     if (!latest) return
-    setCloudMessage('Syncing…')
     const result = await backupSpreadsheetToDrive({ fileId: latest.id, title: latest.name, content: latest.content, folderId: latest.folderId })
-    setCloudMessage(result.success ? 'Synced' : result.error ?? 'Sync failed.')
+    if (!result.success) toast.add({ title: "Couldn't sync", description: result.error ?? 'Sync failed.', type: 'error', priority: 'low' })
   }
 
   const copyDriveLink = async () => {
     if (!file.driveFileId) return
     const result = await copyDriveFileLink(file.driveFileId)
-    setCloudMessage(result.success ? 'Backup link copied.' : result.error ?? 'Could not copy the backup link.')
+    toast.add({
+      title: result.success ? 'Backup link copied' : 'Could not copy the backup link',
+      description: result.success ? undefined : result.error,
+      type: result.success ? 'success' : 'error',
+      priority: 'low',
+    })
   }
   const handleMenuAction = (key: Key) => {
     if (key === 'save') void save()
@@ -224,12 +226,13 @@ export function UniverSpreadsheetEditor({ fileId }: { fileId: string }) {
     if (key === 'delete') setIsDeleteDialogOpen(true)
     if (key === 'close') void close()
   }
+  const editorStatus = file.syncStatus === 'failed' && status !== 'editing' && status !== 'saving-locally' && status !== 'saved-locally' ? 'failed' : status
 
   return (
     <section className="-mx-4 -my-6 flex min-h-0 flex-col sm:-mx-6 lg:-mx-8" style={{ height: editorHeight }}>
       <header className="z-30 flex min-h-16 shrink-0 items-center gap-2 border-b border-[var(--app-border)] bg-background px-2 sm:px-4">
         <button type="button" onClick={() => void close()} aria-label="Close spreadsheet" className="flex size-11 shrink-0 items-center justify-center rounded-[10px]"><ArrowLeftIcon aria-hidden="true" className="size-5" /></button>
-        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={status} />{cloudMessage ? <p className="mt-1 text-xs text-muted-foreground">{cloudMessage}</p> : null}{file.lastSyncedAt || file.syncError ? <p className="mt-1 text-xs text-muted-foreground">{file.lastSyncedAt ? `Synced ${new Date(file.lastSyncedAt).toLocaleString()}` : ''}{file.syncError ? `${file.lastSyncedAt ? ' · ' : ''}${file.syncError}` : ''}</p> : null}<div className="mt-1"><FolderBreadcrumb currentFolderId={file.folderId} folders={folders} currentPageLabel={file.name} onNavigate={navigate} /></div></div>
+        <div className="min-w-0 flex-1"><h1 className="truncate text-base font-semibold">{file.name}</h1><EditorStatus status={editorStatus} onRetry={() => void backupNow()} /><div className="mt-1"><FolderBreadcrumb currentFolderId={file.folderId} folders={folders} currentPageLabel={file.name} onNavigate={navigate} /></div></div>
         <Dropdown><Dropdown.Trigger aria-label="More spreadsheet actions" className="flex size-11 items-center justify-center rounded-[10px]"><EllipsisHorizontalIcon aria-hidden="true" className="size-6" /></Dropdown.Trigger><Dropdown.Popover placement="bottom end"><Dropdown.Menu aria-label="Spreadsheet actions" onAction={handleMenuAction}><Dropdown.Item id="save">Save now</Dropdown.Item><Dropdown.Item id="backup">Sync now</Dropdown.Item><Dropdown.Item id="open-drive" isDisabled={!file.driveFileId}>Open backup in Drive</Dropdown.Item><Dropdown.Item id="copy-link" isDisabled={!file.driveFileId}>Copy backup link</Dropdown.Item><Dropdown.Item id="duplicate">Duplicate</Dropdown.Item><Dropdown.Item id="download-local">Download local copy</Dropdown.Item><Dropdown.Item id="import"><span className="flex items-center gap-2"><ArrowUpTrayIcon aria-hidden="true" className="size-5" />Import XLSX</span></Dropdown.Item><Dropdown.Item id="export">Export XLSX</Dropdown.Item><Dropdown.Item id="download"><span className="flex items-center gap-2"><ArrowDownTrayIcon aria-hidden="true" className="size-5" />Download XLSX</span></Dropdown.Item><Dropdown.Item id="delete" variant="danger">Move to Trash</Dropdown.Item><Dropdown.Item id="close">Close spreadsheet</Dropdown.Item></Dropdown.Menu></Dropdown.Popover></Dropdown>
         <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void save()}>Save</AppButton>
         <AppButton className="hidden sm:flex" variant="secondary" onPress={() => void backupNow()}>Sync now</AppButton>

--- a/src/database/repositories.test.ts
+++ b/src/database/repositories.test.ts
@@ -2,8 +2,9 @@ import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { db } from './db'
-import { fileRepository, folderRepository, processPendingDriveFolderSync } from './repositories'
+import { fileRepository, folderRepository, processPendingDriveFolderSync, queueLocalItemsForDriveBackup } from './repositories'
 import { ensureMyBookDriveFolder, ensureVisibleFolderInParent } from '../services/googleDrive'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 
 vi.mock('../services/googleDrive', () => ({
   backupDocumentToDrive: vi.fn().mockResolvedValue({ success: true, folderId: 'mybook-root', folderName: 'MyBook', created: true }),
@@ -16,9 +17,13 @@ vi.mock('../services/googleDrive', () => ({
 
 describe('IndexedDB repositories', () => {
   beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(ensureMyBookDriveFolder).mockResolvedValue({ success: false, error: 'offline' })
+    vi.mocked(ensureVisibleFolderInParent).mockReset()
     await db.delete()
     await db.open()
     vi.stubGlobal('navigator', { onLine: false })
+    useWorkspaceStore.setState({ mode: null })
   })
 
   it('creates, renames, deletes, and restores a file locally', async () => {
@@ -60,6 +65,88 @@ describe('IndexedDB repositories', () => {
     expect(queue).toHaveLength(2)
     await processPendingDriveFolderSync()
     expect((await db.syncQueue.toArray())[0]?.status).toBe('pending')
+  })
+
+  it('does not queue Drive work for a local workspace', async () => {
+    useWorkspaceStore.setState({ mode: 'local' })
+
+    const file = await fileRepository.create('document')
+    const folder = await folderRepository.create('Local folder')
+    await fileRepository.update(file.data!.id, { content: '{"type":"doc","content":[{"type":"paragraph"}]}', folderId: folder.data!.id })
+
+    expect(file.data?.syncStatus).toBe('local')
+    expect((await db.files.get(file.data!.id))?.syncStatus).toBe('local')
+    expect(await db.syncQueue.toArray()).toHaveLength(0)
+    expect(ensureMyBookDriveFolder).not.toHaveBeenCalled()
+  })
+
+  it('hides cached Drive files and folders in local workspace mode', async () => {
+    const now = new Date().toISOString()
+    await db.folders.bulkAdd([
+      { id: 'drive-folder', driveFolderId: 'drive-folder-id', name: 'Drive folder', parentId: null, createdAt: now, updatedAt: now, isDeleted: false },
+      { id: 'local-folder', driveFolderId: null, workspaceType: 'local', name: 'Local folder', parentId: null, createdAt: now, updatedAt: now, isDeleted: false },
+    ])
+    await db.files.bulkAdd([
+      { id: 'drive-file', driveFileId: 'drive-file-id', name: 'Drive file', type: 'document', folderId: null, content: '', mimeType: 'application/x-mybook-document', createdAt: now, updatedAt: now, lastSyncedAt: now, syncStatus: 'backed-up', isDeleted: false },
+      { id: 'local-file', driveFileId: null, workspaceType: 'local', name: 'Local file', type: 'document', folderId: null, content: '', mimeType: 'application/x-mybook-document', createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: 'local', isDeleted: false },
+    ])
+
+    useWorkspaceStore.setState({ mode: 'local' })
+
+    expect((await fileRepository.list()).map((file) => file.id)).toEqual(['local-file'])
+    expect((await folderRepository.list()).map((folder) => folder.id)).toEqual(['local-folder'])
+    expect((await fileRepository.get('drive-file')).data).toBeUndefined()
+    expect((await folderRepository.get('drive-folder')).data).toBeUndefined()
+  })
+
+  it('treats legacy unmarked rows as Drive workspace items', async () => {
+    const now = new Date().toISOString()
+    await db.files.add({ id: 'legacy-drive-file', driveFileId: 'drive-file-id', name: 'Drive file', type: 'document', folderId: null, content: '', mimeType: 'application/x-mybook-document', createdAt: now, updatedAt: now, lastSyncedAt: now, syncStatus: 'backed-up', isDeleted: false })
+
+    useWorkspaceStore.setState({ mode: 'drive' })
+
+    expect((await fileRepository.list()).map((file) => file.id)).toEqual(['legacy-drive-file'])
+  })
+
+  it('does not wait for Drive sync before completing a local content update', async () => {
+    vi.stubGlobal('navigator', { onLine: true })
+    vi.mocked(ensureMyBookDriveFolder).mockImplementation(() => new Promise(() => undefined))
+    const now = new Date().toISOString()
+    await db.files.add({
+      id: 'drive-file',
+      driveFileId: null,
+      workspaceType: 'drive',
+      name: 'Drive file',
+      type: 'document',
+      folderId: null,
+      content: '',
+      mimeType: 'application/x-mybook-document',
+      createdAt: now,
+      updatedAt: now,
+      lastSyncedAt: null,
+      syncStatus: 'pending',
+      isDeleted: false,
+    })
+
+    await expect(fileRepository.update('drive-file', { content: 'changed', syncStatus: 'pending' })).resolves.toEqual({ success: true })
+    expect((await db.files.get('drive-file'))?.content).toBe('changed')
+    expect((await db.syncQueue.toArray())).toHaveLength(1)
+  })
+
+  it('queues local workspace files when switching to Drive backup', async () => {
+    useWorkspaceStore.setState({ mode: 'local' })
+    const file = await fileRepository.create('document')
+    const folder = await folderRepository.create('Local folder')
+    expect(await db.syncQueue.toArray()).toHaveLength(0)
+
+    useWorkspaceStore.setState({ mode: 'drive' })
+    await queueLocalItemsForDriveBackup()
+
+    expect((await db.files.get(file.data!.id))?.syncStatus).toBe('pending')
+    expect((await db.syncQueue.toArray()).map((item) => `${item.entityType}:${item.entityId}`).sort()).toEqual([
+      `file:${file.data!.id}`,
+      `folder:${folder.data!.id}`,
+    ])
   })
 
   it('creates a nested Drive folder under its synced parent', async () => {

--- a/src/database/repositories.ts
+++ b/src/database/repositories.ts
@@ -1,6 +1,8 @@
 import { db } from './db'
-import type { AppSetting, FileType, FileVersionSource, MyBookFile, MyBookFolder, SyncOperation, SyncQueueItem } from '../types/files'
+import type { AppSetting, FileType, FileVersionSource, MyBookFile, MyBookFolder, SyncOperation, SyncQueueItem, WorkspaceType } from '../types/files'
 import { backupDocumentToDrive, backupSpreadsheetToDrive, ensureMyBookDriveFolder, ensureVisibleFolderInParent, restoreDriveFile, restoreDriveFolder, trashDriveFile, trashDriveFolder, updateDriveFolder } from '../services/googleDrive'
+import { deleteLocalWorkspaceFile, readLocalWorkspaceFile, writeLocalWorkspaceFile } from '../services/localWorkspace'
+import { isLocalWorkspace, shouldSyncWithDrive } from '../stores/useWorkspaceStore'
 import { devLog } from '../utils/safeLog'
 
 export interface RepositoryResult<T = void> {
@@ -46,6 +48,67 @@ async function queueFileSync(fileId: string, operation: SyncOperation, errorMess
     return
   }
   await db.syncQueue.add({ id: crypto.randomUUID(), entityId: fileId, entityType: 'file', operation, status: 'pending', retryCount: 0, createdAt: now, updatedAt: now, errorMessage })
+}
+
+async function maybeQueueFolderSync(folderId: string, operation: SyncOperation, errorMessage: string | null = null) {
+  if (!shouldSyncWithDrive()) return
+  await queueFolderSync(folderId, operation, errorMessage)
+}
+
+async function maybeQueueFileSync(fileId: string, operation: SyncOperation, errorMessage: string | null = null) {
+  if (!shouldSyncWithDrive()) return
+  await queueFileSync(fileId, operation, errorMessage)
+}
+
+async function maybeProcessPendingDriveSync() {
+  if (shouldSyncWithDrive() && navigator.onLine) await processPendingDriveSync()
+}
+
+function processPendingDriveSyncInBackground() {
+  void maybeProcessPendingDriveSync().catch((error) => {
+    devLog('warn', 'Could not process pending Drive sync in the background.', error)
+  })
+}
+
+function initialSyncStatus() {
+  return isLocalWorkspace() ? 'local' as const : 'pending' as const
+}
+
+function pendingSyncStatus() {
+  return isLocalWorkspace() ? 'local' as const : 'pending' as const
+}
+
+function activeWorkspaceType(): WorkspaceType {
+  return isLocalWorkspace() ? 'local' : 'drive'
+}
+
+function fileBelongsToActiveWorkspace(file: MyBookFile) {
+  if (isLocalWorkspace()) {
+    return file.workspaceType === 'local' || (!file.workspaceType && file.syncStatus === 'local' && !file.driveFileId)
+  }
+  return file.workspaceType !== 'local'
+}
+
+function folderBelongsToActiveWorkspace(folder: MyBookFolder) {
+  if (isLocalWorkspace()) return folder.workspaceType === 'local'
+  return folder.workspaceType !== 'local'
+}
+
+async function persistLocalFile(file: MyBookFile | undefined) {
+  if (isLocalWorkspace() && file) await writeLocalWorkspaceFile(file)
+}
+
+async function hydrateLocalFile(file: MyBookFile | undefined) {
+  if (!file || !fileBelongsToActiveWorkspace(file)) return undefined
+  if (!isLocalWorkspace()) return file
+  const localContent = await readLocalWorkspaceFile(file)
+  return localContent === null ? file : { ...file, content: localContent }
+}
+
+async function folderIsInActiveWorkspace(folderId: string | null) {
+  if (!folderId) return true
+  const folder = await db.folders.get(folderId)
+  return Boolean(folder && folderBelongsToActiveWorkspace(folder) && !folder.isDeleted)
 }
 
 async function ensureLocalFolderOnDrive(folderId: string | null, visiting = new Set<string>()): Promise<string> {
@@ -102,6 +165,7 @@ async function syncFileItem(item: SyncQueueItem) {
 }
 
 export async function processPendingDriveSync() {
+  if (!shouldSyncWithDrive()) return
   if (!navigator.onLine) return
   const queue = await db.syncQueue.filter((item) => item.status !== 'completed').sortBy('createdAt')
   for (const item of queue) {
@@ -137,8 +201,22 @@ export async function processPendingDriveSync() {
 
 export const processPendingDriveFolderSync = processPendingDriveSync
 
+export async function queueLocalItemsForDriveBackup() {
+  if (!shouldSyncWithDrive()) return
+  const folders = await db.folders.filter((folder) => !folder.isDeleted && folder.workspaceType === 'local').toArray()
+  const files = await db.files.filter((file) => !file.isDeleted && file.workspaceType === 'local').toArray()
+  await Promise.all(folders.map(async (folder) => {
+    await db.folders.update(folder.id, { workspaceType: 'drive' })
+    await queueFolderSync(folder.id, 'create')
+  }))
+  await Promise.all(files.map(async (file) => {
+    await db.files.update(file.id, { workspaceType: 'drive', syncStatus: 'pending', syncError: null })
+    await queueFileSync(file.id, 'create')
+  }))
+}
+
 async function uniqueFileName(name: string, folderId: string | null, excludedId?: string) {
-  const files = await db.files.filter((file) => file.folderId === folderId).toArray()
+  const files = await db.files.filter((file) => file.folderId === folderId && fileBelongsToActiveWorkspace(file)).toArray()
   return !files.some((file) => file.id !== excludedId && !file.isDeleted && file.folderId === folderId && appFileName(file.name, file.type).toLocaleLowerCase() === name.toLocaleLowerCase())
 }
 
@@ -183,18 +261,20 @@ export const fileRepository = {
   async create(type: FileType, folderId: string | null = null): Promise<RepositoryResult<MyBookFile>> {
     try {
       const now = new Date().toISOString()
+      if (!(await folderIsInActiveWorkspace(folderId))) return { success: false, error: 'Folder could not be found in this workspace.' }
       const name = await nextFileName(type === 'document' ? 'Untitled Document' : 'Untitled Spreadsheet', folderId)
-      const file: MyBookFile = { id: crypto.randomUUID(), driveFileId: null, name, type, folderId, content: '', mimeType: type === 'document' ? 'application/x-mybook-document' : 'application/x-mybook-spreadsheet', createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: 'pending', isDeleted: false }
+      const file: MyBookFile = { id: crypto.randomUUID(), driveFileId: null, workspaceType: activeWorkspaceType(), name, type, folderId, content: '', mimeType: type === 'document' ? 'application/x-mybook-document' : 'application/x-mybook-spreadsheet', createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: initialSyncStatus(), isDeleted: false }
       await db.files.add(file)
-      await queueFileSync(file.id, 'create', navigator.onLine ? null : 'Offline. File will sync when you reconnect.')
-      if (navigator.onLine) await processPendingDriveSync()
+      await persistLocalFile(file)
+      await maybeQueueFileSync(file.id, 'create', navigator.onLine ? null : 'Offline. File will sync when you reconnect.')
+      await maybeProcessPendingDriveSync()
       const synced = await db.files.get(file.id)
       return { success: true, data: synced ?? file }
     } catch (error) { return failure(error, 'Could not create file.') }
   },
   async get(id: string) {
     try {
-      const file = await db.files.get(id)
+      const file = await hydrateLocalFile(await db.files.get(id))
       return { success: true, data: file ? { ...file, name: appFileName(file.name, file.type) } : file }
     } catch (error) { return failure(error, 'Could not load file.') }
   },
@@ -202,6 +282,7 @@ export const fileRepository = {
     try {
       const existing = await db.files.get(id)
       if (!existing) return { success: false, error: 'File could not be found.' }
+      if (!fileBelongsToActiveWorkspace(existing)) return { success: false, error: 'File could not be found in this workspace.' }
       if (changes.content !== undefined && changes.content === existing.content && Object.keys(changes).every((key) => key === 'content')) return { success: true }
       if (changes.name !== undefined) {
         const name = appFileName(changes.name, existing.type)
@@ -211,10 +292,15 @@ export const fileRepository = {
         if (!(await uniqueFileName(name, changes.folderId ?? file.folderId, id))) return { success: false, error: 'A file with this name already exists here.' }
         changes = { ...changes, name }
       }
-      await db.files.update(id, { ...changes, updatedAt: new Date().toISOString() })
+      const nextChanges = isLocalWorkspace()
+        ? { ...changes, syncStatus: pendingSyncStatus(), syncError: null }
+        : changes
+      if (nextChanges.folderId !== undefined && !(await folderIsInActiveWorkspace(nextChanges.folderId))) return { success: false, error: 'Folder could not be found in this workspace.' }
+      await db.files.update(id, { ...nextChanges, updatedAt: new Date().toISOString() })
+      await persistLocalFile(await db.files.get(id))
       if (changes.name !== undefined || changes.folderId !== undefined || changes.content !== undefined) {
-        await queueFileSync(id, existing.driveFileId ? 'update' : 'create', navigator.onLine ? null : 'Offline. File changes will sync when you reconnect.')
-        if (navigator.onLine) await processPendingDriveSync()
+        await maybeQueueFileSync(id, existing.driveFileId ? 'update' : 'create', navigator.onLine ? null : 'Offline. File changes will sync when you reconnect.')
+        processPendingDriveSyncInBackground()
       }
       return { success: true }
     } catch (error) { return failure(error, 'Could not update file.') }
@@ -223,9 +309,10 @@ export const fileRepository = {
     try {
       const file = await db.files.get(id)
       if (!file) return { success: false, error: 'File could not be found.' }
+      if (!fileBelongsToActiveWorkspace(file)) return { success: false, error: 'File could not be found in this workspace.' }
       await db.files.update(id, { isDeleted: true, updatedAt: new Date().toISOString() })
-      await queueFileSync(id, 'delete', navigator.onLine ? null : 'Offline. File will move to Drive Trash when you reconnect.')
-      if (navigator.onLine) await processPendingDriveSync()
+      await maybeQueueFileSync(id, 'delete', navigator.onLine ? null : 'Offline. File will move to Drive Trash when you reconnect.')
+      await maybeProcessPendingDriveSync()
       return { success: true }
     } catch (error) { return failure(error, 'Could not delete file.') }
   },
@@ -233,16 +320,18 @@ export const fileRepository = {
     try {
       const file = await db.files.get(id)
       if (!file) return { success: false, error: 'File could not be found.' }
+      if (!fileBelongsToActiveWorkspace(file)) return { success: false, error: 'File could not be found in this workspace.' }
       await db.files.update(id, { isDeleted: false, updatedAt: new Date().toISOString() })
-      await queueFileSync(id, file.driveFileId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. File restore will sync when you reconnect.')
-      if (navigator.onLine) await processPendingDriveSync()
+      await persistLocalFile(await db.files.get(id))
+      await maybeQueueFileSync(id, file.driveFileId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. File restore will sync when you reconnect.')
+      await maybeProcessPendingDriveSync()
       return { success: true }
     } catch (error) { return failure(error, 'Could not restore file.') }
   },
-  async permanentlyDelete(id: string): Promise<RepositoryResult> { try { await db.files.delete(id); return { success: true } } catch (error) { return failure(error, 'Could not permanently delete file.') } },
+  async permanentlyDelete(id: string): Promise<RepositoryResult> { try { const file = await db.files.get(id); if (file && !fileBelongsToActiveWorkspace(file)) return { success: false, error: 'File could not be found in this workspace.' }; if (file) await deleteLocalWorkspaceFile(file); await db.files.delete(id); return { success: true } } catch (error) { return failure(error, 'Could not permanently delete file.') } },
   async list(includeDeleted = false): Promise<MyBookFile[]> {
     try {
-      const files = await db.files.filter((file) => includeDeleted || !file.isDeleted).toArray()
+      const files = await db.files.filter((file) => fileBelongsToActiveWorkspace(file) && (includeDeleted || !file.isDeleted)).toArray()
       const normalized = files.map((file) => ({ ...file, name: appFileName(file.name, file.type) }))
       return includeDeleted ? normalized : uniqueLogicalFiles(normalized)
     } catch (error) { devLog('error', 'Could not list files.', error); return [] }
@@ -250,7 +339,7 @@ export const fileRepository = {
   async search(query: string): Promise<MyBookFile[]> {
     try {
       const value = query.trim().toLocaleLowerCase()
-      const files = (await db.files.filter((file) => !file.isDeleted && appFileName(file.name, file.type).toLocaleLowerCase().includes(value)).toArray())
+      const files = (await db.files.filter((file) => fileBelongsToActiveWorkspace(file) && !file.isDeleted && appFileName(file.name, file.type).toLocaleLowerCase().includes(value)).toArray())
         .map((file) => ({ ...file, name: appFileName(file.name, file.type) }))
       return uniqueLogicalFiles(files)
     } catch (error) { devLog('error', 'Could not search files.', error); return [] }
@@ -259,14 +348,16 @@ export const fileRepository = {
     try {
       const source = await db.files.get(id)
       if (!source) return { success: false, error: 'File could not be found.' }
+      if (!fileBelongsToActiveWorkspace(source)) return { success: false, error: 'File could not be found in this workspace.' }
       const now = new Date().toISOString()
       let copyName = `${source.name} copy`
       let suffix = 2
       while (!(await uniqueFileName(copyName, source.folderId))) copyName = `${source.name} copy ${suffix++}`
-      const copy = { ...source, id: crypto.randomUUID(), driveFileId: null, name: copyName, createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: 'pending' as const, isDeleted: false }
+      const copy = { ...source, id: crypto.randomUUID(), driveFileId: null, workspaceType: activeWorkspaceType(), name: copyName, createdAt: now, updatedAt: now, lastSyncedAt: null, syncStatus: initialSyncStatus(), isDeleted: false }
       await db.files.add(copy)
-      await queueFileSync(copy.id, 'create', navigator.onLine ? null : 'Offline. File copy will sync when you reconnect.')
-      if (navigator.onLine) await processPendingDriveSync()
+      await persistLocalFile(copy)
+      await maybeQueueFileSync(copy.id, 'create', navigator.onLine ? null : 'Offline. File copy will sync when you reconnect.')
+      await maybeProcessPendingDriveSync()
       return { success: true, data: (await db.files.get(copy.id)) ?? copy }
     } catch (error) { return failure(error, 'Could not duplicate file.') }
   },
@@ -277,7 +368,8 @@ export const folderRepository = {
     try {
       const normalized = cleanName(name)
       if (!normalized) return { success: false, error: 'Folder name cannot be empty.' }
-      const siblings = await db.folders.filter((folder) => !folder.isDeleted && folder.parentId === parentId).toArray()
+      if (!(await folderIsInActiveWorkspace(parentId))) return { success: false, error: 'Parent folder could not be found in this workspace.' }
+      const siblings = await db.folders.filter((folder) => folderBelongsToActiveWorkspace(folder) && !folder.isDeleted && folder.parentId === parentId).toArray()
       if (siblings.some((folder) => folder.name.toLocaleLowerCase() === normalized.toLocaleLowerCase())) return { success: false, error: `"${normalized}" already exists. Use a different name.` }
       let depth = 1
       let ancestorId = parentId
@@ -287,21 +379,21 @@ export const folderRepository = {
       }
       if (depth > 3) return { success: false, error: 'Folders can be nested up to three levels.' }
       const now = new Date().toISOString()
-      const folder: MyBookFolder = { id: crypto.randomUUID(), driveFolderId: null, name: normalized, parentId, createdAt: now, updatedAt: now, isDeleted: false }
+      const folder: MyBookFolder = { id: crypto.randomUUID(), driveFolderId: null, workspaceType: activeWorkspaceType(), name: normalized, parentId, createdAt: now, updatedAt: now, isDeleted: false }
       await db.folders.add(folder)
-      await queueFolderSync(folder.id, 'create', navigator.onLine ? null : 'Offline. Folder will sync when you reconnect.')
-      if (navigator.onLine) await processPendingDriveSync()
+      await maybeQueueFolderSync(folder.id, 'create', navigator.onLine ? null : 'Offline. Folder will sync when you reconnect.')
+      await maybeProcessPendingDriveSync()
       return { success: true, data: (await db.folders.get(folder.id)) ?? folder }
     } catch (error) { return failure(error, 'Could not create folder.') }
   },
-  async get(id: string) { try { return { success: true, data: await db.folders.get(id) } } catch (error) { return failure(error, 'Could not load folder.') } },
+  async get(id: string) { try { const folder = await db.folders.get(id); return { success: true, data: folder && folderBelongsToActiveWorkspace(folder) ? folder : undefined } } catch (error) { return failure(error, 'Could not load folder.') } },
   async update(id: string, changes: Partial<Omit<MyBookFolder, 'id'>>): Promise<RepositoryResult> {
     try {
-      const folder = await db.folders.get(id); if (!folder) return { success: false, error: 'Folder could not be found.' }
+      const folder = await db.folders.get(id); if (!folder || !folderBelongsToActiveWorkspace(folder)) return { success: false, error: 'Folder could not be found.' }
       const targetParentId = changes.parentId !== undefined ? changes.parentId : folder.parentId
       if (targetParentId === id) return { success: false, error: 'A folder cannot be moved inside itself.' }
       if (changes.parentId !== undefined) {
-        const allFolders = await db.folders.toArray()
+        const allFolders = (await db.folders.toArray()).filter(folderBelongsToActiveWorkspace)
         const descendants = new Set<string>()
         let changed = true
         while (changed) {
@@ -328,31 +420,33 @@ export const folderRepository = {
       }
       if (changes.name !== undefined) { const name = cleanName(changes.name); if (!name) return { success: false, error: 'Folder name cannot be empty.' }; changes = { ...changes, name } }
       const nextName = changes.name ?? folder.name
-      const siblings = await db.folders.filter((item) => !item.isDeleted && item.id !== id && item.parentId === targetParentId).toArray()
+      const siblings = await db.folders.filter((item) => folderBelongsToActiveWorkspace(item) && !item.isDeleted && item.id !== id && item.parentId === targetParentId).toArray()
       if (siblings.some((item) => item.name.toLocaleLowerCase() === nextName.toLocaleLowerCase())) return { success: false, error: `"${nextName}" already exists. Use a different name.` }
       const next = { ...changes, updatedAt: new Date().toISOString() }
       await db.folders.update(id, next)
       if (changes.name !== undefined || changes.parentId !== undefined) {
-        await queueFolderSync(id, folder.driveFolderId ? 'update' : 'create', navigator.onLine ? null : 'Offline. Folder changes will sync when you reconnect.')
-        if (navigator.onLine) await processPendingDriveSync()
+        await maybeQueueFolderSync(id, folder.driveFolderId ? 'update' : 'create', navigator.onLine ? null : 'Offline. Folder changes will sync when you reconnect.')
+        await maybeProcessPendingDriveSync()
       }
       return { success: true }
     } catch (error) { return failure(error, 'Could not update folder.') }
   },
   async delete(id: string): Promise<RepositoryResult> {
     try {
+      const folder = await db.folders.get(id)
+      if (!folder || !folderBelongsToActiveWorkspace(folder)) return { success: false, error: 'Folder could not be found.' }
       let deletedFolderIds: string[] = []
       await db.transaction('rw', db.folders, db.files, async () => {
-        const allFolders = await db.folders.toArray()
+        const allFolders = (await db.folders.toArray()).filter(folderBelongsToActiveWorkspace)
         const ids = new Set([id]); let changed = true
         while (changed) { changed = false; allFolders.forEach((folder) => { if (folder.parentId && ids.has(folder.parentId) && !ids.has(folder.id)) { ids.add(folder.id); changed = true } }) }
         deletedFolderIds = [...ids]
         const now = new Date().toISOString()
         await Promise.all([...ids].map((folderId) => db.folders.update(folderId, { isDeleted: true, updatedAt: now })))
-        await db.files.filter((file) => Boolean(file.folderId && ids.has(file.folderId))).modify({ isDeleted: true, updatedAt: now })
+        await db.files.filter((file) => fileBelongsToActiveWorkspace(file) && Boolean(file.folderId && ids.has(file.folderId))).modify({ isDeleted: true, updatedAt: now })
       })
-      await Promise.all(deletedFolderIds.map((folderId) => queueFolderSync(folderId, 'delete', navigator.onLine ? null : 'Offline. Folder will move to Drive Trash when you reconnect.')))
-      if (navigator.onLine) await processPendingDriveFolderSync()
+      await Promise.all(deletedFolderIds.map((folderId) => maybeQueueFolderSync(folderId, 'delete', navigator.onLine ? null : 'Offline. Folder will move to Drive Trash when you reconnect.')))
+      await maybeProcessPendingDriveSync()
       return { success: true }
     } catch (error) { return failure(error, 'Could not delete folder.') }
   },
@@ -362,8 +456,8 @@ export const folderRepository = {
       let restoredFileIds: string[] = []
       await db.transaction('rw', db.folders, db.files, async () => {
         const folder = await db.folders.get(id)
-        if (!folder) throw new Error('Folder could not be found.')
-        const allFolders = await db.folders.toArray()
+        if (!folder || !folderBelongsToActiveWorkspace(folder)) throw new Error('Folder could not be found.')
+        const allFolders = (await db.folders.toArray()).filter(folderBelongsToActiveWorkspace)
         const ids = new Set([id])
         let changed = true
         while (changed) {
@@ -378,29 +472,29 @@ export const folderRepository = {
         restoredFolderIds = [...ids]
         const now = new Date().toISOString()
         await Promise.all(restoredFolderIds.map((folderId) => db.folders.update(folderId, { isDeleted: false, updatedAt: now })))
-        const nestedFiles = await db.files.filter((file) => Boolean(file.folderId && ids.has(file.folderId))).toArray()
+        const nestedFiles = await db.files.filter((file) => fileBelongsToActiveWorkspace(file) && Boolean(file.folderId && ids.has(file.folderId))).toArray()
         restoredFileIds = nestedFiles.map((file) => file.id)
         await Promise.all(restoredFileIds.map((fileId) => db.files.update(fileId, { isDeleted: false, updatedAt: now })))
       })
       const restoredFolders = await db.folders.bulkGet(restoredFolderIds)
       await Promise.all(restoredFolders
         .filter((folder): folder is MyBookFolder => Boolean(folder))
-        .map((folder) => queueFolderSync(folder.id, folder.driveFolderId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. Folder restore will sync when you reconnect.')))
+        .map((folder) => maybeQueueFolderSync(folder.id, folder.driveFolderId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. Folder restore will sync when you reconnect.')))
       const restoredFiles = await db.files.bulkGet(restoredFileIds)
       await Promise.all(restoredFiles
         .filter((file): file is MyBookFile => Boolean(file))
-        .map((file) => queueFileSync(file.id, file.driveFileId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. File restore will sync when you reconnect.')))
-      if (navigator.onLine) {
-        await processPendingDriveFolderSync()
-        await processPendingDriveSync()
-      }
+        .map(async (file) => {
+          await persistLocalFile(file)
+          await maybeQueueFileSync(file.id, file.driveFileId ? 'restore' : 'create', navigator.onLine ? null : 'Offline. File restore will sync when you reconnect.')
+        }))
+      await maybeProcessPendingDriveSync()
       return { success: true }
     } catch (error) {
       return failure(error, 'Could not restore folder.')
     }
   },
-  async list(): Promise<MyBookFolder[]> { try { return await db.folders.filter((folder) => !folder.isDeleted).toArray() } catch (error) { devLog('error', 'Could not list folders.', error); return [] } },
-  async search(query: string): Promise<MyBookFolder[]> { try { const value = query.trim().toLocaleLowerCase(); return await db.folders.filter((folder) => !folder.isDeleted && folder.name.toLocaleLowerCase().includes(value)).toArray() } catch (error) { devLog('error', 'Could not search folders.', error); return [] } },
+  async list(): Promise<MyBookFolder[]> { try { return await db.folders.filter((folder) => folderBelongsToActiveWorkspace(folder) && !folder.isDeleted).toArray() } catch (error) { devLog('error', 'Could not list folders.', error); return [] } },
+  async search(query: string): Promise<MyBookFolder[]> { try { const value = query.trim().toLocaleLowerCase(); return await db.folders.filter((folder) => folderBelongsToActiveWorkspace(folder) && !folder.isDeleted && folder.name.toLocaleLowerCase().includes(value)).toArray() } catch (error) { devLog('error', 'Could not search folders.', error); return [] } },
 }
 
 export const settingsRepository = {
@@ -436,17 +530,19 @@ export const fileVersionRepository = {
       if (!version) return { success: false, error: 'Version could not be found.' }
       const file = await db.files.get(version.fileId)
       if (!file) return { success: false, error: 'File could not be found.' }
+      if (!fileBelongsToActiveWorkspace(file)) return { success: false, error: 'File could not be found in this workspace.' }
       await saveFileVersion(file, 'local', 'Before version restore')
       await db.files.update(file.id, {
         content: version.content,
         name: version.name,
         mimeType: version.mimeType,
-        syncStatus: 'pending',
+        syncStatus: pendingSyncStatus(),
         syncError: null,
         updatedAt: new Date().toISOString(),
       })
-      await queueFileSync(file.id, file.driveFileId ? 'update' : 'create')
-      if (navigator.onLine) await processPendingDriveSync()
+      await persistLocalFile(await db.files.get(file.id))
+      await maybeQueueFileSync(file.id, file.driveFileId ? 'update' : 'create')
+      await maybeProcessPendingDriveSync()
       const restored = await db.files.get(file.id)
       return { success: true, data: restored }
     } catch (error) {

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { fileRepository } from '../database/repositories'
+import { isLocalWorkspace } from '../stores/useWorkspaceStore'
 import type { EditorSaveStatus, MyBookFile } from '../types/files'
 
 const SAVE_DELAY = 500
 
 export function useAutosave(file: MyBookFile | undefined) {
-  const recoveryKey = file ? `mybook-recovery:${file.id}` : ''
   const [content, setContent] = useState('')
   const [isHydrated, setIsHydrated] = useState(false)
-  const [status, setStatus] = useState<EditorSaveStatus>(navigator.onLine ? 'pending' : 'offline')
+  const [status, setStatus] = useState<EditorSaveStatus>(isLocalWorkspace() ? 'local' : navigator.onLine ? 'pending' : 'offline')
   const lastSaved = useRef(file?.content ?? '')
   const contentRef = useRef(content)
   const fileRef = useRef(file)
@@ -18,18 +18,8 @@ export function useAutosave(file: MyBookFile | undefined) {
   useEffect(() => {
     if (!file) return
     setIsHydrated(false)
-    const draft = localStorage.getItem(`mybook-recovery:${file.id}`)
-    let next = file.content
-    if (draft) {
-      try {
-        const recovered = JSON.parse(draft) as { content?: unknown }
-        if (typeof recovered.content === 'string') next = recovered.content
-      } catch {
-        localStorage.removeItem(`mybook-recovery:${file.id}`)
-      }
-    }
+    const next = file.content
     setContent(next); contentRef.current = next; lastSaved.current = file.content
-    if (next !== file.content) setStatus('editing')
     setIsHydrated(true)
   }, [file])
 
@@ -37,12 +27,11 @@ export function useAutosave(file: MyBookFile | undefined) {
     const currentFile = fileRef.current
     if (!currentFile || contentRef.current === lastSaved.current) return true
     setStatus('saving-locally')
-    const result = await fileRepository.update(currentFile.id, { content: contentRef.current, syncStatus: 'pending' })
+    const result = await fileRepository.update(currentFile.id, { content: contentRef.current, syncStatus: isLocalWorkspace() ? 'local' : 'pending' })
     if (!result.success) { setStatus('failed'); return false }
     lastSaved.current = contentRef.current
-    localStorage.removeItem(`mybook-recovery:${currentFile.id}`)
     setStatus('saved-locally')
-    window.setTimeout(() => setStatus(navigator.onLine ? 'pending' : 'offline'), 700)
+    window.setTimeout(() => setStatus(isLocalWorkspace() ? 'local' : navigator.onLine ? 'pending' : 'offline'), 700)
     return true
   }, [])
 
@@ -66,14 +55,12 @@ export function useAutosave(file: MyBookFile | undefined) {
 
   const changeContent = (value: string) => {
     setContent(value); contentRef.current = value; setStatus('editing')
-    if (file) localStorage.setItem(recoveryKey, JSON.stringify({ content: value, updatedAt: new Date().toISOString() }))
   }
 
   const replaceContent = (value: string, nextStatus: EditorSaveStatus = 'saved-locally') => {
     setContent(value)
     contentRef.current = value
     lastSaved.current = value
-    if (file) localStorage.removeItem(recoveryKey)
     setStatus(nextStatus)
   }
 

--- a/src/hooks/useDriveBootstrap.ts
+++ b/src/hooks/useDriveBootstrap.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 
 import { backfillLocalFoldersToDrive, ensureMyBookDriveFolder, getDriveFolderStatus, importDriveFilesToLocal, importDriveFoldersToLocal } from '../services/googleDrive'
 import { useAuthStore } from '../stores/useAuthStore'
-import { folderRepository, processPendingDriveFolderSync, settingsRepository } from '../database/repositories'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { folderRepository, processPendingDriveFolderSync, queueLocalItemsForDriveBackup, settingsRepository } from '../database/repositories'
 
 const DRIVE_BACKFILL_KEY = 'google-drive.folder-backfill-complete'
 let importDriveBackupsFlight: Promise<void> | null = null
@@ -20,12 +21,13 @@ async function importDriveBackupsToLocal() {
 export function useDriveBootstrap() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const email = useAuthStore((state) => state.email)
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
   const [isPreparing, setIsPreparing] = useState(false)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [folderId, setFolderId] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!isAuthenticated || !email) return
+    if (workspaceMode === 'local' || !isAuthenticated || !email) return
     let cancelled = false
     const run = async () => {
       setIsPreparing(true)
@@ -58,6 +60,8 @@ export function useDriveBootstrap() {
           }
           await settingsRepository.update(DRIVE_BACKFILL_KEY, true)
         }
+        await queueLocalItemsForDriveBackup()
+        await processPendingDriveFolderSync()
       } finally {
         if (!cancelled) setIsPreparing(false)
       }
@@ -71,7 +75,7 @@ export function useDriveBootstrap() {
       cancelled = true
       window.removeEventListener('online', onlineHandler)
     }
-  }, [email, isAuthenticated])
+  }, [email, isAuthenticated, workspaceMode])
 
   return { isPreparing, statusMessage, folderId }
 }

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -1,9 +1,11 @@
 import { useLiveQuery } from 'dexie-react-hooks'
 
 import { fileRepository, folderRepository } from '../database/repositories'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 
 export function useLibraryData(includeDeleted = false) {
-  const files = useLiveQuery(() => fileRepository.list(includeDeleted), [includeDeleted], [])
-  const folders = useLiveQuery(() => folderRepository.list(), [], [])
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
+  const files = useLiveQuery(() => fileRepository.list(includeDeleted), [includeDeleted, workspaceMode], [])
+  const folders = useLiveQuery(() => folderRepository.list(), [workspaceMode], [])
   return { files, folders, isLoading: files === undefined || folders === undefined }
 }

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LoginPage } from './LoginPage'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { initializeLocalWorkspace, pickLocalWorkspaceDirectory } from '../services/localWorkspace'
+
+const mockLocalWorkspaceSupport = vi.hoisted(() => ({ canPickDeviceDirectory: false }))
+const pickedDirectory = vi.hoisted(() => ({ handle: { name: 'Writing Vault' } as FileSystemDirectoryHandle, name: 'Writing Vault' }))
+
+vi.mock('../utils/googleIdentity', () => ({
+  loadGoogleIdentity: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../services/localWorkspace', async () => {
+  const actual = await vi.importActual<typeof import('../services/localWorkspace')>('../services/localWorkspace')
+  return {
+    ...actual,
+    canPickDeviceDirectory: () => mockLocalWorkspaceSupport.canPickDeviceDirectory,
+    initializeLocalWorkspace: vi.fn().mockResolvedValue({ storage: 'opfs' }),
+    pickLocalWorkspaceDirectory: vi.fn().mockResolvedValue(pickedDirectory),
+  }
+})
+
+function renderLoginPage() {
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/home" element={<p>Home</p>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginPage local workspace setup', () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ mode: null })
+    mockLocalWorkspaceSupport.canPickDeviceDirectory = false
+    vi.mocked(initializeLocalWorkspace).mockResolvedValue({ storage: 'opfs' })
+    vi.mocked(pickLocalWorkspaceDirectory).mockResolvedValue(pickedDirectory)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('defaults to private app storage when a device folder picker is unavailable', async () => {
+    renderLoginPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Local Workspace' }))
+
+    expect(screen.getByRole('dialog', { name: 'Create local workspace' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /Choose a folder on this device/ })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Use private app storage/ })).toBeChecked()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Workspace' }))
+
+    await waitFor(() => expect(screen.getByText('Home')).toBeInTheDocument())
+    expect(initializeLocalWorkspace).toHaveBeenCalledWith({
+      name: 'My Workspace',
+      storagePreference: 'private',
+      allowPrivateFallback: true,
+      directoryHandle: undefined,
+    })
+  })
+
+  it('defaults to device-folder storage when supported', () => {
+    mockLocalWorkspaceSupport.canPickDeviceDirectory = true
+    renderLoginPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Local Workspace' }))
+
+    expect(screen.getByRole('radio', { name: /Choose a folder on this device/ })).toBeChecked()
+    expect(screen.getByRole('button', { name: 'Browse folder' })).toBeInTheDocument()
+    expect(screen.getByText('No folder selected yet.')).toBeInTheDocument()
+  })
+
+  it('shows the selected folder and creates the workspace with that folder handle', async () => {
+    mockLocalWorkspaceSupport.canPickDeviceDirectory = true
+    renderLoginPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Local Workspace' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Browse folder' }))
+
+    expect(await screen.findByText('Selected folder: Writing Vault')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Workspace' }))
+
+    await waitFor(() => expect(screen.getByText('Home')).toBeInTheDocument())
+    expect(initializeLocalWorkspace).toHaveBeenCalledWith({
+      name: 'My Workspace',
+      storagePreference: 'file-system',
+      allowPrivateFallback: false,
+      directoryHandle: pickedDirectory.handle,
+    })
+  })
+
+  it('requires browsing before creating a device-folder workspace', async () => {
+    mockLocalWorkspaceSupport.canPickDeviceDirectory = true
+
+    renderLoginPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Local Workspace' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create Workspace' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Choose a folder before creating')
+    expect(screen.queryByText('Home')).not.toBeInTheDocument()
+    expect(initializeLocalWorkspace).not.toHaveBeenCalled()
+    expect(useWorkspaceStore.getState().mode).toBeNull()
+  })
+})

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,12 +1,21 @@
 import {
   BookOpenIcon,
   ExclamationCircleIcon,
+  FolderOpenIcon,
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { authApiUrl, getAuthConfigError, isBackendAuthEnabled, useAuthStore } from '../stores/useAuthStore'
+import {
+  canPickDeviceDirectory,
+  initializeLocalWorkspace,
+  pickLocalWorkspaceDirectory,
+  type LocalWorkspaceStoragePreference,
+  type PickedLocalWorkspaceDirectory,
+} from '../services/localWorkspace'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { loadGoogleIdentity } from '../utils/googleIdentity'
 import { getSafeReturnPath } from '../utils/navigation'
 
@@ -18,10 +27,19 @@ export function LoginPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const googleButtonRef = useRef<HTMLDivElement>(null)
+  const [isLocalSetupOpen, setIsLocalSetupOpen] = useState(false)
+  const [workspaceName, setWorkspaceName] = useState('My Workspace')
+  const [storagePreference, setStoragePreference] = useState<LocalWorkspaceStoragePreference>('private')
+  const [selectedDirectory, setSelectedDirectory] = useState<PickedLocalWorkspaceDirectory | null>(null)
+  const [localSetupError, setLocalSetupError] = useState<string | null>(null)
+  const [isPickingDirectory, setIsPickingDirectory] = useState(false)
+  const [isCreatingLocalWorkspace, setIsCreatingLocalWorkspace] = useState(false)
   const { clearError, error, isLoading, completeLogin } = useAuthStore()
+  const { createLocalWorkspace, selectGoogleWorkspace } = useWorkspaceStore()
   const destination = getSafeReturnPath((location.state as LoginLocationState | null)?.from)
   const queryError = new URLSearchParams(location.search).get('error')
   const configError = getAuthConfigError()
+  const supportsDeviceFolder = useMemo(() => canPickDeviceDirectory(), [])
 
   useEffect(() => {
     clearError()
@@ -43,7 +61,10 @@ export function LoginPage() {
               return
             }
             void completeLogin(response.credential, '').then((succeeded) => {
-              if (succeeded) navigate(destination, { replace: true })
+              if (succeeded) {
+                selectGoogleWorkspace()
+                navigate(destination, { replace: true })
+              }
             })
           },
         })
@@ -66,10 +87,59 @@ export function LoginPage() {
     return () => {
       active = false
     }
-  }, [completeLogin, configError, destination, navigate])
+  }, [completeLogin, configError, destination, navigate, selectGoogleWorkspace])
 
   const startBackendLogin = () => {
+    selectGoogleWorkspace()
     window.location.assign(`${authApiUrl('/google/start')}?returnTo=${encodeURIComponent(destination)}`)
+  }
+
+  useEffect(() => {
+    setStoragePreference(supportsDeviceFolder ? 'file-system' : 'private')
+  }, [supportsDeviceFolder])
+
+  const openLocalSetup = () => {
+    setLocalSetupError(null)
+    setIsLocalSetupOpen(true)
+  }
+
+  const browseLocalFolder = async () => {
+    setStoragePreference('file-system')
+    setLocalSetupError(null)
+    setIsPickingDirectory(true)
+    try {
+      const directory = await pickLocalWorkspaceDirectory()
+      if (!directory) {
+        setLocalSetupError('Choose a folder to create a device-folder workspace.')
+        return
+      }
+      setSelectedDirectory(directory)
+    } finally {
+      setIsPickingDirectory(false)
+    }
+  }
+
+  const startLocalWorkspace = async () => {
+    const name = workspaceName.trim() || 'My Workspace'
+    if (storagePreference === 'file-system' && !selectedDirectory) {
+      setLocalSetupError('Choose a folder before creating this workspace, or use private app storage.')
+      return
+    }
+    setIsCreatingLocalWorkspace(true)
+    setLocalSetupError(null)
+    const result = await initializeLocalWorkspace({
+      name,
+      storagePreference,
+      allowPrivateFallback: storagePreference !== 'file-system',
+      directoryHandle: selectedDirectory?.handle,
+    })
+    if ('cancelled' in result && result.cancelled) {
+      setLocalSetupError('Choose a folder to create a device-folder workspace, or switch to private app storage.')
+      setIsCreatingLocalWorkspace(false)
+      return
+    }
+    createLocalWorkspace()
+    navigate('/home', { replace: true })
   }
 
   return (
@@ -82,7 +152,7 @@ export function LoginPage() {
           MyBook
         </h1>
         <p className="mt-2 text-base leading-7 text-muted-foreground">
-          Your private documents and spreadsheets, backed up to your Drive.
+          Your private documents and spreadsheets, on this device or backed up to your Drive.
         </p>
 
         {error || queryError ? (
@@ -92,7 +162,14 @@ export function LoginPage() {
           </div>
         ) : null}
 
-        <div className="mt-7 flex justify-center">
+        <div className="mt-7 grid gap-3">
+          <button
+            type="button"
+            onClick={openLocalSetup}
+            className="min-h-11 rounded-[var(--radius-control)] bg-foreground px-5 text-base font-semibold text-background transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+          >
+            Create Local Workspace
+          </button>
           {isBackendAuthEnabled ? (
             <button
               type="button"
@@ -102,7 +179,7 @@ export function LoginPage() {
               Continue with Google
             </button>
           ) : (
-            <div ref={googleButtonRef} />
+            <div className="flex justify-center" ref={googleButtonRef} />
           )}
         </div>
 
@@ -116,7 +193,7 @@ export function LoginPage() {
         <div className="mt-6 flex items-start gap-3 border-t border-[var(--app-border)] pt-5">
           <ShieldCheckIcon aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-emerald-600" />
           <p className="text-sm leading-6 text-muted-foreground">
-            Your files will be stored in your own Google Drive. MyBook will only
+            Local workspaces stay on this device. Google workspaces use your own Drive and only
             request access needed to manage files you create here.
           </p>
         </div>
@@ -126,6 +203,135 @@ export function LoginPage() {
           </p>
         ) : null}
       </section>
+
+      {isLocalSetupOpen ? (
+        <div className="fixed inset-0 z-50 flex items-end bg-black/40 px-3 pb-3 pt-[calc(1rem+env(safe-area-inset-top))] sm:items-center sm:justify-center sm:p-6" role="presentation">
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="local-workspace-title"
+            className="max-h-full w-full max-w-lg overflow-y-auto rounded-t-2xl border border-[var(--app-border)] bg-background p-5 shadow-xl sm:rounded-2xl sm:p-6"
+          >
+            <div className="flex items-start gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <FolderOpenIcon aria-hidden="true" className="size-6" />
+              </div>
+              <div>
+                <h2 id="local-workspace-title" className="text-lg font-semibold leading-7">
+                  Create local workspace
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  Choose where this device should keep your Writin files.
+                </p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  Local workspaces are tied to this browser unless you choose the same device folder again on a supported browser. Use Google Drive when you need the same files everywhere.
+                </p>
+              </div>
+            </div>
+
+            <label htmlFor="workspace-name" className="mt-5 block text-sm font-medium text-foreground">
+              Workspace name
+            </label>
+            <input
+              id="workspace-name"
+              value={workspaceName}
+              onChange={(event) => setWorkspaceName(event.target.value)}
+              className="mt-2 h-11 w-full rounded-[var(--radius-control)] border border-[var(--app-border)] bg-background px-3 text-base outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20"
+              placeholder="My Workspace"
+            />
+
+            <fieldset className="mt-5">
+              <legend className="text-sm font-medium text-foreground">Storage location</legend>
+              <div className="mt-2 grid gap-3">
+                <label
+                  className={`flex cursor-pointer gap-3 rounded-lg border p-4 transition ${supportsDeviceFolder ? 'border-[var(--app-border)] hover:border-[var(--accent)]/60' : 'cursor-not-allowed border-[var(--app-border)] bg-muted/40 opacity-70'} ${storagePreference === 'file-system' ? 'ring-2 ring-[var(--accent)]/30' : ''}`}
+                >
+                  <input
+                    type="radio"
+                    name="local-storage"
+                    value="file-system"
+                    checked={storagePreference === 'file-system'}
+                    disabled={!supportsDeviceFolder}
+                    onChange={() => setStoragePreference('file-system')}
+                    className="mt-1 size-4 accent-[var(--accent)]"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-foreground">Choose a folder on this device</span>
+                    <span className="mt-1 block text-sm leading-6 text-muted-foreground">
+                      Best for macOS, Windows, and supported Android browsers. Files stay visible outside the app.
+                    </span>
+                    {!supportsDeviceFolder ? (
+                      <span className="mt-1 block text-xs font-medium text-muted-foreground">
+                        Folder selection is not available in this browser.
+                      </span>
+                    ) : null}
+                    {supportsDeviceFolder ? (
+                      <span className="mt-4 block border-t border-[var(--app-border)] pt-3">
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.preventDefault()
+                            void browseLocalFolder()
+                          }}
+                          disabled={isPickingDirectory || isCreatingLocalWorkspace}
+                          className="min-h-10 rounded-[var(--radius-control)] border border-[var(--app-border)] px-3 text-sm font-semibold transition hover:bg-muted disabled:opacity-60"
+                        >
+                          {isPickingDirectory ? 'Opening...' : selectedDirectory ? 'Change folder' : 'Browse folder'}
+                        </button>
+                        <span className="mt-2 block text-xs font-medium text-muted-foreground">
+                          {selectedDirectory ? `Selected folder: ${selectedDirectory.name}` : 'No folder selected yet.'}
+                        </span>
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+
+                <label className={`flex cursor-pointer gap-3 rounded-lg border border-[var(--app-border)] p-4 transition hover:border-[var(--accent)]/60 ${storagePreference === 'private' ? 'ring-2 ring-[var(--accent)]/30' : ''}`}>
+                  <input
+                    type="radio"
+                    name="local-storage"
+                    value="private"
+                    checked={storagePreference === 'private'}
+                    onChange={() => setStoragePreference('private')}
+                    className="mt-1 size-4 accent-[var(--accent)]"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-foreground">Use private app storage</span>
+                    <span className="mt-1 block text-sm leading-6 text-muted-foreground">
+                      Works across devices including iPhone and iPad. Export backups or connect Drive to protect local-only work.
+                    </span>
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+
+            {localSetupError ? (
+              <p role="alert" className="mt-4 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                {localSetupError}
+              </p>
+            ) : null}
+
+            <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setIsLocalSetupOpen(false)}
+                disabled={isCreatingLocalWorkspace}
+                className="min-h-11 rounded-[var(--radius-control)] border border-[var(--app-border)] px-4 text-sm font-semibold transition hover:bg-muted disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void startLocalWorkspace()}
+                disabled={isCreatingLocalWorkspace}
+                className="min-h-11 rounded-[var(--radius-control)] bg-foreground px-4 text-sm font-semibold text-background transition hover:opacity-90 disabled:opacity-60"
+              >
+                {isCreatingLocalWorkspace ? 'Creating...' : 'Create Workspace'}
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
     </main>
   )
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -14,6 +14,7 @@ import { FolderCard } from '../components/files/FolderCard'
 import { FolderNameDialog } from '../components/files/FolderNameDialog'
 import { fileRepository, folderRepository } from '../database/repositories'
 import { useLibraryData } from '../hooks/useLibraryData'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import type { MyBookFile, MyBookFolder } from '../types/files'
 import { formatUpdatedAt } from '../utils/dateFormat'
 import { deletedToast } from '../utils/deleteToast'
@@ -26,6 +27,7 @@ type SearchResult =
 export function SearchPage() {
   const navigate = useNavigate()
   const { files, folders } = useLibraryData()
+  const workspaceMode = useWorkspaceStore((state) => state.mode)
   const [query, setQuery] = useState('')
   const [renameTarget, setRenameTarget] = useState<MyBookFile | null>(null)
   const [folderRenameTarget, setFolderRenameTarget] = useState<MyBookFolder | null>(null)
@@ -95,7 +97,7 @@ export function SearchPage() {
                   name={folder.name}
                   fileCount={fileCount(folder.id)}
                   folderCount={folderCount(folder.id)}
-                  driveStatus={folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
+                  driveStatus={workspaceMode === 'local' ? 'Stored locally' : folder.driveFolderId ? 'Synced to Drive' : 'Drive folder pending'}
                   onOpen={() => navigate(`/folders/${folder.id}`)}
                   action={
                     <FolderActionsMenu

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightStartOnRectangleIcon, MoonIcon, SunIcon, TrashIcon } from '@heroicons/react/24/outline'
-import { useEffect, useState } from 'react'
+import { ArrowDownTrayIcon, ArrowRightStartOnRectangleIcon, ArrowUpTrayIcon, CloudArrowUpIcon, MoonIcon, ShieldCheckIcon, SunIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useLiveQuery } from 'dexie-react-hooks'
 
@@ -7,20 +7,31 @@ import { AppButton } from '../components/common/AppButton'
 import { PageHeader } from '../components/common/PageHeader'
 import { useDriveBootstrap } from '../hooks/useDriveBootstrap'
 import { getDriveFolderStatus, openMyBookFolderInDrive } from '../services/googleDrive'
+import { exportLocalWorkspaceBackup, importLocalWorkspaceBackup } from '../services/localBackup'
+import { getLocalStorageProtectionStatus, requestPersistentLocalStorage } from '../services/localWorkspace'
 import { useAuthStore } from '../stores/useAuthStore'
 import { db } from '../database/db'
 import { processPendingDriveFolderSync } from '../database/repositories'
 import { APP_VERSION } from '../config/app'
 import { useAppStore } from '../stores/useAppStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { toast } from '../components/ui/toast'
 
 export function SettingsPage() {
   const { email, logout, reconnect } = useAuthStore()
+  const { mode: workspaceMode, clearWorkspace, selectGoogleWorkspace } = useWorkspaceStore()
   const { theme, toggleTheme } = useAppStore()
   const navigate = useNavigate()
+  const backupInputRef = useRef<HTMLInputElement>(null)
   const { isPreparing, statusMessage } = useDriveBootstrap()
   const [storedFolderId, setStoredFolderId] = useState<string | null>(null)
   const [databaseStatus, setDatabaseStatus] = useState<'checking' | 'ready' | 'failed'>('checking')
-  const files = useLiveQuery(() => db.files.filter((file) => !file.isDeleted).toArray(), [], []) ?? []
+  const [storageStatus, setStorageStatus] = useState<{ persisted: boolean; usage?: number; quota?: number } | null>(null)
+  const [backupAction, setBackupAction] = useState<'export' | 'import' | 'persist' | null>(null)
+  const files = useLiveQuery(() => db.files.filter((file) => {
+    const belongsToLocal = file.workspaceType === 'local' || (!file.workspaceType && file.syncStatus === 'local' && !file.driveFileId)
+    return !file.isDeleted && (workspaceMode === 'local' ? belongsToLocal : !belongsToLocal)
+  }).toArray(), [workspaceMode], []) ?? []
   const syncQueue = useLiveQuery(() => db.syncQueue.toArray(), [], []) ?? []
   const backupStats = {
     total: files.length,
@@ -32,19 +43,79 @@ export function SettingsPage() {
   useEffect(() => {
     let active = true
     const load = async () => {
+      if (workspaceMode === 'local') {
+        setStoredFolderId(null)
+        return
+      }
       const id = await getDriveFolderStatus()
       if (active) setStoredFolderId(id)
     }
     void load()
     return () => { active = false }
-  }, [])
+  }, [workspaceMode])
   useEffect(() => {
     void db.open().then(() => setDatabaseStatus('ready')).catch(() => setDatabaseStatus('failed'))
+  }, [])
+  useEffect(() => {
+    let active = true
+    void getLocalStorageProtectionStatus().then((status) => {
+      if (active) setStorageStatus(status)
+    }).catch(() => {
+      if (active) setStorageStatus({ persisted: false })
+    })
+    return () => { active = false }
   }, [])
 
   const handleLogout = async () => {
     await logout()
+    clearWorkspace()
     navigate('/login', { replace: true, state: null })
+  }
+
+  const isLocalMode = workspaceMode === 'local'
+
+  const protectStorage = async () => {
+    setBackupAction('persist')
+    try {
+      const persisted = await requestPersistentLocalStorage()
+      const nextStatus = await getLocalStorageProtectionStatus()
+      setStorageStatus(nextStatus)
+      toast.add({ title: persisted ? 'Local storage protection enabled' : 'Storage protection is not available here', type: persisted ? 'success' : 'warning', priority: 'low' })
+    } finally {
+      setBackupAction(null)
+    }
+  }
+
+  const exportBackup = async () => {
+    setBackupAction('export')
+    try {
+      const result = await exportLocalWorkspaceBackup()
+      toast.add({ title: result.method === 'share' ? 'Backup ready to save' : 'Backup downloaded', description: result.fileName, type: 'success', priority: 'low' })
+    } catch (error) {
+      toast.add({ title: 'Could not export backup', description: error instanceof Error ? error.message : 'Please try again.', type: 'error', priority: 'low' })
+    } finally {
+      setBackupAction(null)
+    }
+  }
+
+  const importBackup = async (file: File | undefined) => {
+    if (!file) return
+    setBackupAction('import')
+    try {
+      const result = await importLocalWorkspaceBackup(file)
+      toast.add({ title: 'Backup imported', description: `${result.fileCount} files restored into a new folder.`, type: 'success', priority: 'low' })
+      navigate(`/folders/${result.folderId}`)
+    } catch (error) {
+      toast.add({ title: 'Could not import backup', description: error instanceof Error ? error.message : 'Choose a valid MyBook backup file.', type: 'error', priority: 'low' })
+    } finally {
+      setBackupAction(null)
+      if (backupInputRef.current) backupInputRef.current.value = ''
+    }
+  }
+
+  const connectDriveBackup = () => {
+    selectGoogleWorkspace()
+    navigate('/login', { replace: false, state: { from: '/settings' } })
   }
 
   return (
@@ -64,44 +135,100 @@ export function SettingsPage() {
       <section aria-labelledby="account-heading" className="rounded-2xl bg-muted/70 p-4">
         <h2 id="account-heading" className="text-base font-semibold leading-6">Account</h2>
         <p className="mt-1 text-sm leading-6 text-muted-foreground">
-          {email ? `Signed in as ${email}.` : 'Your Google session will appear here after sign-in.'}
+          {isLocalMode ? 'Using a local workspace on this device.' : email ? `Signed in as ${email}.` : 'Your Google session will appear here after sign-in.'}
         </p>
         <AppButton className="mt-4" variant="secondary" onPress={() => void handleLogout()}>
           <ArrowRightStartOnRectangleIcon aria-hidden="true" className="size-5" />
-          Log out
+          {isLocalMode ? 'Return to start' : 'Log out'}
         </AppButton>
       </section>
       <section aria-labelledby="drive-heading" className="rounded-2xl bg-muted/70 p-4">
         <h2 id="drive-heading" className="text-base font-semibold leading-6">Google Drive</h2>
         <p className="mt-1 text-sm leading-6 text-muted-foreground">
-          {isPreparing
+          {isLocalMode
+            ? 'Google Drive is not connected for this local workspace.'
+            : isPreparing
             ? 'Checking your MyBook Drive folder...'
             : storedFolderId
               ? 'MyBook folder is connected.'
               : 'MyBook folder is not connected yet.'}
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          {statusMessage ?? 'MyBook syncs your files across signed-in devices using Drive backups.'}
+          {isLocalMode ? 'Files are saved locally first. Connect Google Drive to start automatic cloud backup.' : statusMessage ?? 'MyBook syncs your files across signed-in devices using Drive backups.'}
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
           <AppButton
             variant="secondary"
-            isDisabled={!storedFolderId}
+            isDisabled={isLocalMode || !storedFolderId}
             onPress={() => {
               if (storedFolderId) openMyBookFolderInDrive(storedFolderId)
             }}
           >
             Open MyBook folder in Drive
           </AppButton>
-          <AppButton variant="secondary" onPress={() => void reconnect()}>
+          <AppButton variant="secondary" isDisabled={isLocalMode} onPress={() => void reconnect()}>
             Reconnect
           </AppButton>
+          {isLocalMode ? (
+            <AppButton variant="primary" onPress={connectDriveBackup}>
+              <CloudArrowUpIcon aria-hidden="true" className="size-5" />
+              Connect Google Drive backup
+            </AppButton>
+          ) : null}
         </div>
         <dl className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {([['Local files', backupStats.total], ['Synced', backupStats.backedUp], ['Syncing', backupStats.pending], ['Sync paused', backupStats.failed]] as const).map(([label, value]) => <div key={label} className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">{label}</dt><dd className="mt-1 text-2xl font-semibold">{value}</dd></div>)}
+          {([['Local files', backupStats.total], [isLocalMode ? 'Stored locally' : 'Synced', isLocalMode ? backupStats.total : backupStats.backedUp], ['Syncing', isLocalMode ? 0 : backupStats.pending], ['Sync paused', isLocalMode ? 0 : backupStats.failed]] as const).map(([label, value]) => <div key={label} className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">{label}</dt><dd className="mt-1 text-2xl font-semibold">{value}</dd></div>)}
         </dl>
-        {backupStats.failed > 0 ? <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Sync paused</p>{files.filter((file) => file.syncStatus === 'failed').map((file) => <p key={file.id} className="mt-1 text-muted-foreground">{file.name}: {file.syncError ?? 'Sync failed.'}</p>)}</div> : null}
+        {!isLocalMode && backupStats.failed > 0 ? <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Sync paused</p>{files.filter((file) => file.syncStatus === 'failed').map((file) => <p key={file.id} className="mt-1 text-muted-foreground">{file.name}: {file.syncError ?? 'Sync failed.'}</p>)}</div> : null}
       </section>
+      {isLocalMode ? (
+        <section aria-labelledby="backup-heading" className="rounded-2xl bg-muted/70 p-4">
+          <h2 id="backup-heading" className="text-base font-semibold leading-6">Local backup</h2>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Save a backup file to Files or iCloud Drive, or restore a backup into a new imported folder.
+          </p>
+          <dl className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-[var(--app-border)] p-3">
+              <dt className="text-sm text-muted-foreground">Storage protection</dt>
+              <dd className="mt-1 font-medium">{storageStatus?.persisted ? 'Protected' : 'Best effort'}</dd>
+            </div>
+            <div className="rounded-xl border border-[var(--app-border)] p-3">
+              <dt className="text-sm text-muted-foreground">Used</dt>
+              <dd className="mt-1 font-medium">{formatBytes(storageStatus?.usage)}</dd>
+            </div>
+            <div className="rounded-xl border border-[var(--app-border)] p-3">
+              <dt className="text-sm text-muted-foreground">Available quota</dt>
+              <dd className="mt-1 font-medium">{formatBytes(storageStatus?.quota)}</dd>
+            </div>
+          </dl>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <AppButton variant="secondary" isLoading={backupAction === 'persist'} loadingLabel="Checking..." onPress={() => void protectStorage()}>
+              <ShieldCheckIcon aria-hidden="true" className="size-5" />
+              Protect storage
+            </AppButton>
+            <AppButton variant="secondary" isLoading={backupAction === 'export'} loadingLabel="Preparing..." onPress={() => void exportBackup()}>
+              <ArrowUpTrayIcon aria-hidden="true" className="size-5" />
+              Export backup
+            </AppButton>
+            <AppButton variant="secondary" isLoading={backupAction === 'import'} loadingLabel="Importing..." onPress={() => backupInputRef.current?.click()}>
+              <ArrowDownTrayIcon aria-hidden="true" className="size-5" />
+              Import backup
+            </AppButton>
+          </div>
+          <input
+            ref={backupInputRef}
+            type="file"
+            accept=".mybook-backup.json,application/json"
+            aria-hidden="true"
+            className="sr-only"
+            tabIndex={-1}
+            onChange={(event) => void importBackup(event.target.files?.[0])}
+          />
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            Protection helps prevent automatic browser cleanup. Export or Drive backup is still needed before removing app or browser data.
+          </p>
+        </section>
+      ) : null}
       <section aria-labelledby="files-heading" className="rounded-2xl bg-muted/70 p-4">
         <h2 id="files-heading" className="text-base font-semibold leading-6">Files</h2>
         <AppButton className="mt-4" variant="secondary" onPress={() => navigate('/trash')}><TrashIcon aria-hidden="true" className="size-5" />Open Trash</AppButton>
@@ -120,9 +247,21 @@ export function SettingsPage() {
           <div className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">Queued operations</dt><dd className="mt-1 font-medium">{syncQueue.filter((item) => item.status !== 'completed').length}</dd></div>
           <div className="rounded-xl border border-[var(--app-border)] p-3"><dt className="text-sm text-muted-foreground">Failed operations</dt><dd className="mt-1 font-medium">{syncQueue.filter((item) => item.status === 'failed').length}</dd></div>
         </dl>
-        {syncQueue.some((item) => item.status === 'failed') ? <div role="alert" className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Some Drive operations need attention.</p>{syncQueue.filter((item) => item.status === 'failed').slice(0, 5).map((item) => <p key={item.id} className="mt-1 text-muted-foreground">{item.entityType} {item.operation}: {item.errorMessage ?? 'Retry required.'}</p>)}</div> : null}
-        <AppButton className="mt-4" variant="secondary" onPress={() => void processPendingDriveFolderSync()}>Retry Drive sync</AppButton>
+        {!isLocalMode && syncQueue.some((item) => item.status === 'failed') ? <div role="alert" className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm"><p className="font-medium">Some Drive operations need attention.</p>{syncQueue.filter((item) => item.status === 'failed').slice(0, 5).map((item) => <p key={item.id} className="mt-1 text-muted-foreground">{item.entityType} {item.operation}: {item.errorMessage ?? 'Retry required.'}</p>)}</div> : null}
+        <AppButton className="mt-4" variant="secondary" isDisabled={isLocalMode} onPress={() => void processPendingDriveFolderSync()}>Retry Drive sync</AppButton>
       </section>
     </div>
   )
+}
+
+function formatBytes(value: number | undefined) {
+  if (!value) return 'Unknown'
+  const units = ['B', 'KB', 'MB', 'GB'] as const
+  let size = value
+  let unit = 0
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024
+    unit += 1
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
 }

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -415,7 +415,7 @@ export async function backupDocumentToDrive(input: {
     const parentFolder = input.folderId ? await db.folders.get(input.folderId) : null
     const driveParentId = parentFolder?.driveFolderId ?? driveBootstrap.folderId
     try {
-      await db.files.update(file.id, { syncStatus: 'backing-up', syncError: null })
+      await db.files.update(file.id, { workspaceType: 'drive', syncStatus: 'backing-up', syncError: null })
       const latest = await db.files.get(input.fileId)
       const content = latest?.content ?? input.content
       const title = latest?.name ?? input.title
@@ -427,6 +427,7 @@ export async function backupDocumentToDrive(input: {
       const result = await retryWithBackoff(() => uploadMarkdownFile(title, markdown, driveParentId, latest?.driveFileId ?? file.driveFileId))
       await db.files.update(file.id, {
         driveFileId: result.id,
+        workspaceType: 'drive',
         mimeType: 'application/x-mybook-document',
         syncStatus: 'backed-up',
         lastSyncedAt: result.modifiedTime ?? latest?.lastSyncedAt ?? file.lastSyncedAt ?? new Date().toISOString(),
@@ -495,14 +496,14 @@ export async function backupSpreadsheetToDrive(input: {
     const parentFolder = input.folderId ? await db.folders.get(input.folderId) : null
     const driveParentId = parentFolder?.driveFolderId ?? driveBootstrap.folderId
     try {
-      await db.files.update(file.id, { syncStatus: 'backing-up', syncError: null })
+      await db.files.update(file.id, { workspaceType: 'drive', syncStatus: 'backing-up', syncError: null })
       const latest = await db.files.get(input.fileId)
       const { exportWorkbookToXlsx } = await import('../utils/xlsx')
       const snapshot = JSON.parse((latest?.content ?? input.content) || '{}')
       const exported = await exportWorkbookToXlsx(snapshot)
       if (!exported.success || !exported.data) throw new Error(exported.error ?? 'Could not convert the spreadsheet to XLSX.')
       const result = await retryWithBackoff(() => uploadXlsxBlob(latest?.name ?? input.title, exported.data as Blob, driveParentId, latest?.driveFileId ?? file.driveFileId, latest?.mimeType === GOOGLE_SHEET_MIME ? GOOGLE_SHEET_MIME : undefined))
-      await db.files.update(file.id, { driveFileId: result.id, syncStatus: 'backed-up', lastSyncedAt: result.modifiedTime ?? latest?.lastSyncedAt ?? file.lastSyncedAt ?? new Date().toISOString() })
+      await db.files.update(file.id, { driveFileId: result.id, workspaceType: 'drive', syncStatus: 'backed-up', lastSyncedAt: result.modifiedTime ?? latest?.lastSyncedAt ?? file.lastSyncedAt ?? new Date().toISOString() })
       return { success: true, folderId: driveParentId, folderName: 'MyBook', created: !(latest?.driveFileId ?? file.driveFileId), modifiedTime: result.modifiedTime }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not back up the spreadsheet to Google Drive.'
@@ -557,7 +558,7 @@ export async function backfillLocalFoldersToDrive(folders: Array<{ id: string; n
           ? { id: folder.driveFolderId }
           : await ensureVisibleFolderInParent(folder.name, parentDriveId)
         resolved.set(id, driveFolder.id)
-        await db.folders.update(id, { driveFolderId: driveFolder.id, updatedAt: new Date().toISOString() })
+        await db.folders.update(id, { driveFolderId: driveFolder.id, workspaceType: 'drive', updatedAt: new Date().toISOString() })
         results.push({ success: true, driveFolderId: driveFolder.id, created: !folder.driveFolderId })
         pending.delete(id)
         progressed = true
@@ -595,14 +596,14 @@ export async function importDriveFoldersToLocal(
       if (localMatch) {
         matchedLocalId = localMatch.id
         if (localMatch.name !== driveFolder.name || localMatch.parentId !== parentLocalId || localMatch.driveFolderId !== driveFolder.id || localMatch.isDeleted) {
-          await db.folders.update(localMatch.id, { name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, updatedAt: new Date().toISOString(), isDeleted: false })
+          await db.folders.update(localMatch.id, { name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, workspaceType: 'drive', updatedAt: new Date().toISOString(), isDeleted: false })
         }
       } else {
         const now = new Date().toISOString()
         const id = crypto.randomUUID()
         matchedLocalId = id
-        await db.folders.add({ id, name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, createdAt: now, updatedAt: now, isDeleted: false })
-        byNameAndParent.set(`${parentLocalId ?? 'root'}:${driveFolder.name.toLowerCase()}`, { id, name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, createdAt: now, updatedAt: now, isDeleted: false })
+        await db.folders.add({ id, name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, workspaceType: 'drive', createdAt: now, updatedAt: now, isDeleted: false })
+        byNameAndParent.set(`${parentLocalId ?? 'root'}:${driveFolder.name.toLowerCase()}`, { id, name: driveFolder.name, parentId: parentLocalId, driveFolderId: driveFolder.id, workspaceType: 'drive', createdAt: now, updatedAt: now, isDeleted: false })
       }
       await syncChildren(driveFolder.id, matchedLocalId)
     }
@@ -864,6 +865,7 @@ export async function importDriveFilesToLocal() {
           name,
           folderId: parentLocalId,
           driveFileId: driveFile.id,
+          workspaceType: 'drive',
           type,
           mimeType,
           content: nextContent,
@@ -877,6 +879,7 @@ export async function importDriveFilesToLocal() {
         await db.files.add({
           id: localId,
           driveFileId: driveFile.id,
+          workspaceType: 'drive',
           name: localFileName(driveFile.name, fileType),
           type: fileType,
           folderId: parentLocalId,
@@ -931,12 +934,13 @@ export async function refreshDriveFileToLocal(fileId: string): Promise<{ updated
     }
     const content = await readDriveFileAsLocalContent(driveFile, local.id)
     if (!content || content === local.content) {
-      await db.files.update(local.id, { lastSyncedAt: driveModifiedTime, syncStatus: 'backed-up', syncError: null })
+      await db.files.update(local.id, { workspaceType: 'drive', lastSyncedAt: driveModifiedTime, syncStatus: 'backed-up', syncError: null })
       return { updated: false, modifiedTime: driveModifiedTime }
     }
     await saveVersionBeforeDriveUpdate(local.id, driveModifiedTime)
     await db.files.update(local.id, {
       content,
+      workspaceType: 'drive',
       lastSyncedAt: driveModifiedTime,
       syncStatus: 'backed-up',
       syncError: null,

--- a/src/services/localBackup.test.ts
+++ b/src/services/localBackup.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { db } from '../database/db'
+import { exportLocalWorkspaceBackup } from './localBackup'
+
+describe('local workspace backups', () => {
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+    vi.restoreAllMocks()
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:backup')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+  })
+
+  it('falls back to a text/plain share file when JSON files are not shareable', async () => {
+    const now = new Date().toISOString()
+    await db.files.add({
+      id: 'file-1',
+      driveFileId: null,
+      name: 'Notes',
+      type: 'document',
+      folderId: null,
+      content: '{"type":"doc","content":[{"type":"paragraph"}]}',
+      mimeType: 'application/x-mybook-document',
+      createdAt: now,
+      updatedAt: now,
+      lastSyncedAt: null,
+      syncStatus: 'local',
+      isDeleted: false,
+    })
+    const canShare = vi.fn((data: { files?: File[] }) => data.files?.[0]?.type === 'text/plain')
+    const share = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: canShare })
+    Object.defineProperty(navigator, 'share', { configurable: true, value: share })
+
+    const result = await exportLocalWorkspaceBackup()
+
+    expect(result).toMatchObject({ success: true, method: 'share', mimeType: 'text/plain' })
+    expect(canShare).toHaveBeenCalledTimes(2)
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({
+      files: [expect.objectContaining({ name: expect.stringMatching(/\.mybook-backup\.json$/), type: 'text/plain' })],
+    }))
+  })
+
+  it('downloads the backup when file sharing is unavailable', async () => {
+    Object.defineProperty(navigator, 'canShare', { configurable: true, value: vi.fn(() => false) })
+    Object.defineProperty(navigator, 'share', { configurable: true, value: vi.fn() })
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined)
+
+    const result = await exportLocalWorkspaceBackup()
+
+    expect(result).toMatchObject({ success: true, method: 'download' })
+    expect(click).toHaveBeenCalled()
+  })
+})

--- a/src/services/localBackup.ts
+++ b/src/services/localBackup.ts
@@ -1,0 +1,163 @@
+import { db } from '../database/db'
+import { writeLocalWorkspaceFile } from './localWorkspace'
+import type { FileType, MyBookFile, MyBookFileVersion, MyBookFolder } from '../types/files'
+
+const BACKUP_KIND = 'mybook-workspace-backup'
+const BACKUP_VERSION = 1
+
+interface MyBookBackup {
+  kind: typeof BACKUP_KIND
+  version: typeof BACKUP_VERSION
+  exportedAt: string
+  files: MyBookFile[]
+  folders: MyBookFolder[]
+  fileVersions: MyBookFileVersion[]
+}
+
+type NavigatorWithShare = Navigator & {
+  canShare?: (data: { files?: File[] }) => boolean
+  share?: (data: { files?: File[]; title?: string; text?: string }) => Promise<void>
+}
+
+function safeDateStamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function backupFileName() {
+  return `writin-backup-${safeDateStamp()}.mybook-backup.json`
+}
+
+function downloadBlob(blob: Blob, name: string) {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = name
+  anchor.click()
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+function backupShareFiles(content: string, name: string) {
+  return [
+    new File([content], name, { type: 'application/json' }),
+    new File([content], name, { type: 'text/plain' }),
+    new File([content], name),
+  ]
+}
+
+export async function exportLocalWorkspaceBackup() {
+  const backup: MyBookBackup = {
+    kind: BACKUP_KIND,
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    folders: await db.folders.filter((folder) => !folder.isDeleted && folder.workspaceType === 'local').toArray(),
+    files: await db.files.filter((file) => !file.isDeleted && (file.workspaceType === 'local' || (!file.workspaceType && file.syncStatus === 'local' && !file.driveFileId))).toArray(),
+    fileVersions: await db.fileVersions.toArray(),
+  }
+  const name = backupFileName()
+  const content = JSON.stringify(backup, null, 2)
+  const blob = new Blob([content], { type: 'application/json;charset=utf-8' })
+  const shareNavigator = navigator as NavigatorWithShare
+
+  if (shareNavigator.canShare && shareNavigator.share) {
+    for (const file of backupShareFiles(content, name)) {
+      if (!shareNavigator.canShare({ files: [file] })) continue
+      await shareNavigator.share({ files: [file], title: 'Writin backup', text: 'Save this backup to Files or iCloud Drive.' })
+      return { success: true as const, fileName: name, method: 'share' as const, mimeType: file.type || 'none' }
+    }
+  }
+
+  downloadBlob(blob, name)
+  return { success: true as const, fileName: name, method: 'download' as const }
+}
+
+function assertBackup(value: unknown): asserts value is MyBookBackup {
+  if (!value || typeof value !== 'object') throw new Error('Backup file is not valid.')
+  const backup = value as Partial<MyBookBackup>
+  if (backup.kind !== BACKUP_KIND || backup.version !== BACKUP_VERSION) throw new Error('Backup file is not compatible with this app.')
+  if (!Array.isArray(backup.files) || !Array.isArray(backup.folders) || !Array.isArray(backup.fileVersions)) throw new Error('Backup file is incomplete.')
+}
+
+function fileMimeType(type: FileType) {
+  return type === 'document' ? 'application/x-mybook-document' : 'application/x-mybook-spreadsheet'
+}
+
+async function importedRootName(exportedAt: string) {
+  const date = new Date(exportedAt)
+  const baseName = `Imported backup ${Number.isNaN(date.getTime()) ? safeDateStamp() : date.toLocaleDateString()}`
+  const rootFolders = await db.folders.filter((folder) => !folder.isDeleted && folder.parentId === null).toArray()
+  if (!rootFolders.some((folder) => folder.name.toLocaleLowerCase() === baseName.toLocaleLowerCase())) return baseName
+  let suffix = 2
+  let name = `${baseName} ${suffix}`
+  while (rootFolders.some((folder) => folder.name.toLocaleLowerCase() === name.toLocaleLowerCase())) {
+    suffix += 1
+    name = `${baseName} ${suffix}`
+  }
+  return name
+}
+
+export async function importLocalWorkspaceBackup(file: File) {
+  const parsed = JSON.parse(await file.text()) as unknown
+  assertBackup(parsed)
+
+  const now = new Date().toISOString()
+  const folderIdMap = new Map<string, string>()
+  const fileIdMap = new Map<string, string>()
+  const importRootId = crypto.randomUUID()
+  const importRoot: MyBookFolder = {
+    id: importRootId,
+    driveFolderId: null,
+    workspaceType: 'local',
+    name: await importedRootName(parsed.exportedAt),
+    parentId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: false,
+  }
+
+  const sortedFolders = [...parsed.folders].sort((a, b) => Number(Boolean(a.parentId)) - Number(Boolean(b.parentId)))
+  for (const folder of sortedFolders) folderIdMap.set(folder.id, crypto.randomUUID())
+  for (const source of parsed.files) fileIdMap.set(source.id, crypto.randomUUID())
+
+  const folders: MyBookFolder[] = [
+    importRoot,
+    ...sortedFolders.map((folder) => ({
+      ...folder,
+      id: folderIdMap.get(folder.id) ?? crypto.randomUUID(),
+      driveFolderId: null,
+      workspaceType: 'local' as const,
+      parentId: folder.parentId ? folderIdMap.get(folder.parentId) ?? importRootId : importRootId,
+      isDeleted: false,
+    })),
+  ]
+  const files: MyBookFile[] = parsed.files.map((file) => ({
+    ...file,
+    id: fileIdMap.get(file.id) ?? crypto.randomUUID(),
+    driveFileId: null,
+    workspaceType: 'local' as const,
+    folderId: file.folderId ? folderIdMap.get(file.folderId) ?? importRootId : importRootId,
+    mimeType: file.mimeType || fileMimeType(file.type),
+    lastSyncedAt: null,
+    syncError: null,
+    syncStatus: 'local',
+    isDeleted: false,
+  }))
+  const fileVersions: MyBookFileVersion[] = parsed.fileVersions
+    .filter((version) => fileIdMap.has(version.fileId))
+    .map((version) => ({
+      ...version,
+      id: crypto.randomUUID(),
+      fileId: fileIdMap.get(version.fileId) ?? version.fileId,
+      driveFileId: null,
+      driveModifiedTime: null,
+      source: 'local',
+    }))
+
+  await db.transaction('rw', db.folders, db.files, db.fileVersions, async () => {
+    await db.folders.bulkAdd(folders)
+    await db.files.bulkAdd(files)
+    if (fileVersions.length) await db.fileVersions.bulkAdd(fileVersions)
+  })
+  await Promise.all(files.map((item) => writeLocalWorkspaceFile(item)))
+
+  return { success: true as const, folderId: importRootId, fileCount: files.length, folderCount: folders.length - 1 }
+}

--- a/src/services/localWorkspace.ts
+++ b/src/services/localWorkspace.ts
@@ -1,0 +1,254 @@
+import type { JSONContent } from '@tiptap/core'
+
+import { db } from '../database/db'
+import type { MyBookFile } from '../types/files'
+import { documentToMyBookMarkdown, myBookMarkdownToDocument } from '../utils/mybookMarkdown'
+import { devLog } from '../utils/safeLog'
+
+const ROOT_DIR = 'Writin'
+const FILES_DIR = 'files'
+const LOCAL_DIRECTORY_HANDLE_KEY = 'local-workspace.directory-handle'
+const LOCAL_WORKSPACE_DETAILS_KEY = 'local-workspace.details'
+
+type StorageNavigator = Navigator & {
+  storage?: StorageManager & {
+    getDirectory?: () => Promise<FileSystemDirectoryHandle>
+    persist?: () => Promise<boolean>
+    persisted?: () => Promise<boolean>
+    estimate?: () => Promise<StorageEstimate>
+  }
+}
+
+type FileSystemWindow = Window & {
+  showDirectoryPicker?: (options?: { id?: string; mode?: 'read' | 'readwrite' }) => Promise<FileSystemDirectoryHandle>
+}
+
+type PermissionMode = 'read' | 'readwrite'
+type PermissionDescriptor = { mode?: PermissionMode }
+type PermissionedDirectoryHandle = FileSystemDirectoryHandle & {
+  queryPermission?: (descriptor?: PermissionDescriptor) => Promise<PermissionState>
+  requestPermission?: (descriptor?: PermissionDescriptor) => Promise<PermissionState>
+}
+export type LocalWorkspaceStorageKind = 'file-system' | 'opfs' | 'indexeddb'
+export type LocalWorkspaceStoragePreference = 'file-system' | 'private'
+
+export interface LocalWorkspaceDetails {
+  name: string
+  storage: LocalWorkspaceStorageKind
+  createdAt: string
+}
+
+export interface PickedLocalWorkspaceDirectory {
+  handle: FileSystemDirectoryHandle
+  name: string
+}
+
+function opfsRoot() {
+  return (navigator as StorageNavigator).storage?.getDirectory
+}
+
+export function isOpfsAvailable() {
+  return typeof opfsRoot() === 'function'
+}
+
+export async function requestPersistentLocalStorage() {
+  return await (navigator as StorageNavigator).storage?.persist?.() ?? false
+}
+
+export async function getLocalStorageProtectionStatus() {
+  const storage = (navigator as StorageNavigator).storage
+  const [persisted, estimate] = await Promise.all([
+    storage?.persisted?.() ?? Promise.resolve(false),
+    storage?.estimate?.() ?? Promise.resolve({ usage: undefined, quota: undefined } as StorageEstimate),
+  ])
+  return {
+    persisted,
+    usage: estimate.usage,
+    quota: estimate.quota,
+  }
+}
+
+export function canPickDeviceDirectory() {
+  return typeof (window as FileSystemWindow).showDirectoryPicker === 'function'
+}
+
+async function hasReadWritePermission(handle: FileSystemDirectoryHandle) {
+  const permissioned = handle as PermissionedDirectoryHandle
+  if (!permissioned.queryPermission || !permissioned.requestPermission) return true
+  if (await permissioned.queryPermission({ mode: 'readwrite' }) === 'granted') return true
+  return await permissioned.requestPermission({ mode: 'readwrite' }) === 'granted'
+}
+
+async function saveDeviceDirectoryHandle(handle: FileSystemDirectoryHandle) {
+  await db.settings.put({ key: LOCAL_DIRECTORY_HANDLE_KEY, value: handle, updatedAt: new Date().toISOString() })
+}
+
+async function forgetDeviceDirectoryHandle() {
+  await db.settings.delete(LOCAL_DIRECTORY_HANDLE_KEY)
+}
+
+async function saveLocalWorkspaceDetails(details: LocalWorkspaceDetails) {
+  await db.settings.put({ key: LOCAL_WORKSPACE_DETAILS_KEY, value: details, updatedAt: new Date().toISOString() })
+}
+
+export async function pickLocalWorkspaceDirectory(): Promise<PickedLocalWorkspaceDirectory | null> {
+  if (!canPickDeviceDirectory()) return null
+  try {
+    const handle = await (window as FileSystemWindow).showDirectoryPicker?.({
+      id: 'writin-local-workspace',
+      mode: 'readwrite',
+    })
+    if (!handle || !await hasReadWritePermission(handle)) return null
+    return { handle, name: handle.name }
+  } catch (error) {
+    if (!(error instanceof DOMException && error.name === 'AbortError')) {
+      devLog('warn', 'Could not pick a device folder workspace.', error)
+    }
+    return null
+  }
+}
+
+async function getDeviceDirectoryHandle() {
+  return (await db.settings.get(LOCAL_DIRECTORY_HANDLE_KEY))?.value as FileSystemDirectoryHandle | undefined
+}
+
+async function filesDirectory() {
+  const deviceDirectory = await getDeviceDirectoryHandle()
+  if (deviceDirectory && await hasReadWritePermission(deviceDirectory)) {
+    const workspace = await deviceDirectory.getDirectoryHandle(ROOT_DIR, { create: true })
+    return workspace.getDirectoryHandle(FILES_DIR, { create: true })
+  }
+
+  const getDirectory = opfsRoot()
+  if (!getDirectory) return null
+  const root = await getDirectory.call(navigator.storage)
+  const workspace = await root.getDirectoryHandle(ROOT_DIR, { create: true })
+  return workspace.getDirectoryHandle(FILES_DIR, { create: true })
+}
+
+function privateStorageKind(): LocalWorkspaceStorageKind {
+  return isOpfsAvailable() ? 'opfs' : 'indexeddb'
+}
+
+export async function initializeLocalWorkspace({
+  name = 'My Workspace',
+  storagePreference = canPickDeviceDirectory() ? 'file-system' : 'private',
+  allowPrivateFallback = true,
+  directoryHandle,
+}: {
+  name?: string
+  storagePreference?: LocalWorkspaceStoragePreference
+  allowPrivateFallback?: boolean
+  directoryHandle?: FileSystemDirectoryHandle | null
+} = {}) {
+  await requestPersistentLocalStorage()
+  const createdAt = new Date().toISOString()
+  if (storagePreference === 'private' || !canPickDeviceDirectory()) {
+    await forgetDeviceDirectoryHandle()
+    const storage = privateStorageKind()
+    await saveLocalWorkspaceDetails({ name, storage, createdAt })
+    return { storage }
+  }
+
+  try {
+    const handle = directoryHandle ?? await (window as FileSystemWindow).showDirectoryPicker?.({
+      id: 'writin-local-workspace',
+      mode: 'readwrite',
+    })
+    if (!handle) {
+      if (!allowPrivateFallback) return { storage: privateStorageKind(), cancelled: true }
+      const storage = privateStorageKind()
+      await saveLocalWorkspaceDetails({ name, storage, createdAt })
+      return { storage }
+    }
+    if (await hasReadWritePermission(handle)) {
+      await saveDeviceDirectoryHandle(handle)
+      await filesDirectory()
+      await saveLocalWorkspaceDetails({ name, storage: 'file-system', createdAt })
+      return { storage: 'file-system' as const }
+    }
+  } catch (error) {
+    if (!allowPrivateFallback && error instanceof DOMException && error.name === 'AbortError') {
+      return { storage: privateStorageKind(), cancelled: true }
+    }
+    if (!(error instanceof DOMException && error.name === 'AbortError')) {
+      devLog('warn', 'Could not initialize device folder workspace.', error)
+    }
+  }
+  const storage = privateStorageKind()
+  await saveLocalWorkspaceDetails({ name, storage, createdAt })
+  return { storage }
+}
+
+function exactContentFileName(file: Pick<MyBookFile, 'id'>) {
+  return `${file.id}.content.json`
+}
+
+function portableFileName(file: Pick<MyBookFile, 'id' | 'type'>) {
+  return file.type === 'spreadsheet' ? `${file.id}.mybook.json` : `${file.id}.mybook.md`
+}
+
+function documentMarkdown(file: Pick<MyBookFile, 'name' | 'content'>) {
+  try {
+    return documentToMyBookMarkdown(file.name, JSON.parse(file.content) as JSONContent)
+  } catch {
+    return file.content
+  }
+}
+
+function appContentFromStoredFile(file: Pick<MyBookFile, 'type'>, value: string) {
+  if (file.type === 'spreadsheet') return value
+  try {
+    return JSON.stringify(myBookMarkdownToDocument(value))
+  } catch {
+    return value
+  }
+}
+
+export async function writeLocalWorkspaceFile(file: Pick<MyBookFile, 'id' | 'type' | 'name' | 'content'>) {
+  try {
+    const directory = await filesDirectory()
+    if (!directory) return
+    const exactHandle = await directory.getFileHandle(exactContentFileName(file), { create: true })
+    const exactWritable = await exactHandle.createWritable()
+    await exactWritable.write(file.content)
+    await exactWritable.close()
+
+    const portableHandle = await directory.getFileHandle(portableFileName(file), { create: true })
+    const portableWritable = await portableHandle.createWritable()
+    await portableWritable.write(file.type === 'spreadsheet' ? file.content : documentMarkdown(file))
+    await portableWritable.close()
+  } catch (error) {
+    devLog('warn', 'Could not write local workspace file.', error)
+  }
+}
+
+export async function readLocalWorkspaceFile(file: Pick<MyBookFile, 'id' | 'type'>) {
+  try {
+    const directory = await filesDirectory()
+    if (!directory) return null
+    try {
+      const exactHandle = await directory.getFileHandle(exactContentFileName(file))
+      return await (await exactHandle.getFile()).text()
+    } catch {
+      const portableHandle = await directory.getFileHandle(portableFileName(file))
+      const stored = await (await portableHandle.getFile()).text()
+      return appContentFromStoredFile(file, stored)
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function deleteLocalWorkspaceFile(file: Pick<MyBookFile, 'id' | 'type'>) {
+  try {
+    const directory = await filesDirectory()
+    if (!directory) return
+    await Promise.allSettled([
+      directory.removeEntry(exactContentFileName(file)),
+      directory.removeEntry(portableFileName(file)),
+    ])
+  } catch {
+    // Removing a missing OPFS mirror should not block app-level deletion.
+  }
+}

--- a/src/stores/useAuthStore.test.ts
+++ b/src/stores/useAuthStore.test.ts
@@ -112,7 +112,7 @@ describe('auth helpers', () => {
     })
   })
 
-  it('keeps the user signed in when the stored Drive token is expired', async () => {
+  it('requires reconnect when the stored Drive token is expired', async () => {
     localStorage.setItem('mybook-auth', JSON.stringify({
       state: {
         email: 'reader@example.com',
@@ -125,7 +125,46 @@ describe('auth helpers', () => {
     await useAuthStore.persist.rehydrate()
 
     expect(useAuthStore.getState()).toMatchObject({
+      isAuthenticated: false,
+      email: 'reader@example.com',
+      accessToken: null,
+      accessTokenExpiresAt: null,
+    })
+  })
+
+  it.skipIf(isBackendAuthEnabled)('marks Drive auth as disconnected when silent token renewal fails', async () => {
+    Object.defineProperty(window, 'google', {
+      configurable: true,
+      value: {
+        accounts: {
+          oauth2: {
+            initTokenClient: vi.fn((config: { callback: (response: { error?: string; error_description?: string }) => void }) => ({
+              requestAccessToken: vi.fn(() => {
+                config.callback({ error: 'access_denied', error_description: 'Google session expired.' })
+              }),
+            })),
+            revoke: vi.fn(),
+          },
+          id: {
+            disableAutoSelect: vi.fn(),
+            initialize: vi.fn(),
+            prompt: vi.fn(),
+            renderButton: vi.fn(),
+          },
+        },
+      },
+    })
+
+    useAuthStore.setState({
       isAuthenticated: true,
+      email: 'reader@example.com',
+      accessToken: null,
+      accessTokenExpiresAt: null,
+    })
+
+    await expect(useAuthStore.getState().getAccessToken()).resolves.toBeNull()
+    expect(useAuthStore.getState()).toMatchObject({
+      isAuthenticated: false,
       email: 'reader@example.com',
       accessToken: null,
       accessTokenExpiresAt: null,

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -204,14 +204,14 @@ export const useAuthStore = create<AuthState>()(
         try {
           const session = await readBackendSession()
           set({
-            isAuthenticated: session.authenticated || Boolean(get().email),
+            isAuthenticated: session.authenticated,
             isLoading: false,
             error: null,
             email: session.email ?? get().email,
           })
         } catch (error) {
           set({
-            isAuthenticated: Boolean(get().email),
+            isAuthenticated: false,
             isLoading: false,
             error: error instanceof Error ? error.message : 'Could not check your sign-in session.',
           })
@@ -262,7 +262,7 @@ export const useAuthStore = create<AuthState>()(
             })
             .catch((error) => {
               set({
-                isAuthenticated: Boolean(get().email),
+                isAuthenticated: false,
                 accessToken: null,
                 accessTokenExpiresAt: null,
                 error: getFriendlyGoogleAuthError(error) || 'Google Drive needs to reconnect.',
@@ -297,7 +297,7 @@ export const useAuthStore = create<AuthState>()(
           })
           .catch((error) => {
             set({
-              isAuthenticated: true,
+              isAuthenticated: false,
               accessToken: null,
               accessTokenExpiresAt: null,
               error: getFriendlyGoogleAuthError(error) || 'Google Drive needs to reconnect.',
@@ -360,7 +360,7 @@ export const useAuthStore = create<AuthState>()(
           return true
         } catch (error) {
           set({
-            isAuthenticated: Boolean(get().email),
+            isAuthenticated: false,
             isLoading: false,
             error: getFriendlyGoogleAuthError(error) || 'We could not reconnect your Google session.',
           })
@@ -396,7 +396,7 @@ export const useAuthStore = create<AuthState>()(
         if (!isTokenFresh(state.accessTokenExpiresAt)) {
           state.accessToken = null
           state.accessTokenExpiresAt = null
-          state.isAuthenticated = Boolean(state.email)
+          state.isAuthenticated = false
         } else {
           state.isAuthenticated = true
           scheduleExpiry(

--- a/src/stores/useWorkspaceStore.ts
+++ b/src/stores/useWorkspaceStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand'
+import type { StateStorage } from 'zustand/middleware'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+export type WorkspaceMode = 'local' | 'drive'
+
+interface WorkspaceState {
+  mode: WorkspaceMode | null
+  createLocalWorkspace: () => void
+  selectGoogleWorkspace: () => void
+  clearWorkspace: () => void
+}
+
+const memoryStorage = new Map<string, string>()
+const fallbackStorage: StateStorage = {
+  getItem: (name) => memoryStorage.get(name) ?? null,
+  setItem: (name, value) => { memoryStorage.set(name, value) },
+  removeItem: (name) => { memoryStorage.delete(name) },
+}
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set) => ({
+      mode: null,
+      createLocalWorkspace: () => set({ mode: 'local' }),
+      selectGoogleWorkspace: () => set({ mode: 'drive' }),
+      clearWorkspace: () => set({ mode: null }),
+    }),
+    {
+      name: 'mybook-workspace',
+      storage: createJSONStorage(() => (typeof localStorage === 'undefined' ? fallbackStorage : localStorage)),
+    },
+  ),
+)
+
+export function isLocalWorkspace() {
+  return useWorkspaceStore.getState().mode === 'local'
+}
+
+export function shouldSyncWithDrive() {
+  return useWorkspaceStore.getState().mode !== 'local'
+}

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -1,5 +1,6 @@
 export type FileType = 'document' | 'spreadsheet'
-export type SyncStatus = 'pending' | 'backing-up' | 'backed-up' | 'failed' | 'offline'
+export type WorkspaceType = 'local' | 'drive'
+export type SyncStatus = 'local' | 'pending' | 'backing-up' | 'backed-up' | 'failed' | 'offline'
 export type EditorSaveStatus = 'editing' | 'saving-locally' | 'saved-locally' | SyncStatus
 export type FileSort = 'recent' | 'name-asc' | 'name-desc' | 'type' | 'oldest'
 export type FileFilter = 'all' | 'document' | 'spreadsheet'
@@ -7,6 +8,7 @@ export type FileFilter = 'all' | 'document' | 'spreadsheet'
 export interface MyBookFile {
   id: string
   driveFileId: string | null
+  workspaceType?: WorkspaceType
   name: string
   type: FileType
   folderId: string | null
@@ -38,6 +40,7 @@ export interface MyBookFileVersion {
 export interface MyBookFolder {
   id: string
   driveFolderId: string | null
+  workspaceType?: WorkspaceType
   name: string
   parentId: string | null
   createdAt: string


### PR DESCRIPTION
## Summary

Adds Local Workspace support alongside the existing Google Drive workspace flow.

This PR introduces:
- Local Workspace mode without requiring Google login
- Local workspace setup modal with workspace name and storage choice
- Device-folder selection flow for supported browsers
- OPFS/private app storage fallback for unsupported browsers/iOS/PWA
- Local backup export/import support
- Storage protection status/actions
- Workspace scoping so cached Drive files do not appear in Local Workspace
- Google Drive backup connection path from Local Workspace
- Stricter Drive auth handling when mobile/PWA sessions expire
- Simpler editor save status: Saved, Saving..., Offline, or Couldn't sync · Retry
- Faster editor save feedback by running Drive sync in the background after local save

## Testing

- npm run typecheck
- npm run lint
- npm test -- --run
- npm run build

## Notes

`npm run lint` passes with existing Fast Refresh warnings only.

Google Drive behavior is preserved, but Drive sessions now require a valid token/session. If mobile/PWA reopens with an expired token, the user should reconnect instead of editing cached Drive files and getting repeated sync failures.