### PR TITLE
Fix repeated local workspace permission prompts

### DIFF
--- a/src/services/localWorkspace.test.ts
+++ b/src/services/localWorkspace.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { db } from '../database/db'
+import { initializeLocalWorkspace, pickLocalWorkspaceDirectory } from './localWorkspace'
+
+function directoryHandle(name: string) {
+  const filesDirectory = {
+    getDirectoryHandle: vi.fn(),
+  }
+  const workspaceDirectory = {
+    getDirectoryHandle: vi.fn().mockResolvedValue(filesDirectory),
+  }
+  const rootDirectory = {
+    name,
+    queryPermission: vi.fn().mockResolvedValue('prompt'),
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+    getDirectoryHandle: vi.fn().mockResolvedValue(workspaceDirectory),
+  }
+
+  return { rootDirectory, workspaceDirectory, filesDirectory }
+}
+
+describe('local workspace permissions', () => {
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+    vi.restoreAllMocks()
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { persist: vi.fn().mockResolvedValue(true) },
+    })
+  })
+
+  it('uses the folder picker result without requesting permission a second time', async () => {
+    const { rootDirectory } = directoryHandle('Writing Vault')
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(rootDirectory),
+    })
+
+    const result = await pickLocalWorkspaceDirectory()
+
+    expect(result).toEqual({ handle: rootDirectory, name: 'Writing Vault' })
+    expect(rootDirectory.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('creates the selected device-folder workspace without re-prompting for permission', async () => {
+    const { rootDirectory, workspaceDirectory } = directoryHandle('Writing Vault')
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(rootDirectory),
+    })
+
+    await initializeLocalWorkspace({
+      name: 'My Workspace',
+      storagePreference: 'file-system',
+      allowPrivateFallback: false,
+      directoryHandle: rootDirectory as unknown as FileSystemDirectoryHandle,
+    })
+
+    expect(rootDirectory.requestPermission).not.toHaveBeenCalled()
+    expect(rootDirectory.getDirectoryHandle).toHaveBeenCalledWith('Writin', { create: true })
+    expect(workspaceDirectory.getDirectoryHandle).toHaveBeenCalledWith('files', { create: true })
+  })
+})

--- a/src/services/localWorkspace.ts
+++ b/src/services/localWorkspace.ts
@@ -72,10 +72,11 @@ export function canPickDeviceDirectory() {
   return typeof (window as FileSystemWindow).showDirectoryPicker === 'function'
 }
 
-async function hasReadWritePermission(handle: FileSystemDirectoryHandle) {
+async function hasReadWritePermission(handle: FileSystemDirectoryHandle, { request = true } = {}) {
   const permissioned = handle as PermissionedDirectoryHandle
   if (!permissioned.queryPermission || !permissioned.requestPermission) return true
   if (await permissioned.queryPermission({ mode: 'readwrite' }) === 'granted') return true
+  if (!request) return false
   return await permissioned.requestPermission({ mode: 'readwrite' }) === 'granted'
 }
 
@@ -98,7 +99,7 @@ export async function pickLocalWorkspaceDirectory(): Promise<PickedLocalWorkspac
       id: 'writin-local-workspace',
       mode: 'readwrite',
     })
-    if (!handle || !await hasReadWritePermission(handle)) return null
+    if (!handle) return null
     return { handle, name: handle.name }
   } catch (error) {
     if (!(error instanceof DOMException && error.name === 'AbortError')) {
@@ -112,18 +113,25 @@ async function getDeviceDirectoryHandle() {
   return (await db.settings.get(LOCAL_DIRECTORY_HANDLE_KEY))?.value as FileSystemDirectoryHandle | undefined
 }
 
+async function createFilesDirectory(root: FileSystemDirectoryHandle) {
+  const workspace = await root.getDirectoryHandle(ROOT_DIR, { create: true })
+  return workspace.getDirectoryHandle(FILES_DIR, { create: true })
+}
+
 async function filesDirectory() {
   const deviceDirectory = await getDeviceDirectoryHandle()
-  if (deviceDirectory && await hasReadWritePermission(deviceDirectory)) {
-    const workspace = await deviceDirectory.getDirectoryHandle(ROOT_DIR, { create: true })
-    return workspace.getDirectoryHandle(FILES_DIR, { create: true })
+  if (deviceDirectory && await hasReadWritePermission(deviceDirectory, { request: false })) {
+    try {
+      return await createFilesDirectory(deviceDirectory)
+    } catch (error) {
+      devLog('warn', 'Could not open device folder workspace.', error)
+    }
   }
 
   const getDirectory = opfsRoot()
   if (!getDirectory) return null
   const root = await getDirectory.call(navigator.storage)
-  const workspace = await root.getDirectoryHandle(ROOT_DIR, { create: true })
-  return workspace.getDirectoryHandle(FILES_DIR, { create: true })
+  return createFilesDirectory(root)
 }
 
 function privateStorageKind(): LocalWorkspaceStorageKind {
@@ -161,12 +169,10 @@ export async function initializeLocalWorkspace({
       await saveLocalWorkspaceDetails({ name, storage, createdAt })
       return { storage }
     }
-    if (await hasReadWritePermission(handle)) {
-      await saveDeviceDirectoryHandle(handle)
-      await filesDirectory()
-      await saveLocalWorkspaceDetails({ name, storage: 'file-system', createdAt })
-      return { storage: 'file-system' as const }
-    }
+    await createFilesDirectory(handle)
+    await saveDeviceDirectoryHandle(handle)
+    await saveLocalWorkspaceDetails({ name, storage: 'file-system', createdAt })
+    return { storage: 'file-system' as const }
   } catch (error) {
     if (!allowPrivateFallback && error instanceof DOMException && error.name === 'AbortError') {
       return { storage: privateStorageKind(), cancelled: true }


### PR DESCRIPTION
## Summary
- Prevent repeated Android local workspace folder permission prompts after the user picks a folder.
- Treat the folder picker as the explicit permission step and avoid extra `requestPermission()` calls during setup.
- Use silent permission checks during normal file access so background reads/writes do not keep prompting.
- Add regression tests for the local workspace permission flow.

## Checks
- npm test -- --run src/services/localWorkspace.test.ts src/pages/LoginPage.test.tsx src/app/AuthGuards.test.tsx
- npm run lint
- npm run typecheck
- npm test -- --run
- npm run build

## Notes
- `npm run lint` passes with existing fast-refresh warnings.
- `npm run build` passes with existing Vite chunk-size warnings.